### PR TITLE
Resolve dependency conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ project(':yggdrash-core') {
     dependencies {
         compile "io.grpc:grpc-protobuf:${grpcVersion}"
         compile "io.grpc:grpc-stub:${grpcVersion}"
-        compile "io.grpc:grpc-netty-shaded:${grpcVersion}"
+        compile "io.grpc:grpc-netty:${grpcVersion}"
         compile "com.google.protobuf:protobuf-java:${protobufVersion}"
         compile "org.iq80.leveldb:leveldb:${levelDBVersion}"
         compile "org.ehcache:ehcache:${ehcacheVersion}"


### PR DESCRIPTION
- grpc-netty-shaded ...  referenced one or more files that do not exist

```
Caused by: io.grpc.ManagedChannelProvider$ProviderNotFoundException:
No functional server found. Try adding a dependency on the grpc-netty
or grpc-netty-shaded artifact
```