### PR TITLE
Change handler key from peerId to address

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/core/net/PeerHandlerGroup.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/net/PeerHandlerGroup.java
@@ -37,7 +37,7 @@ public interface PeerHandlerGroup extends BranchEventListener {
 
     List<String> getActivePeerList();
 
-    List<String> getActivePeerListOf();
+    List<String> getActiveAddressList();
 
     List<PeerHandler> getHandlerList(BranchId branchId);
 }

--- a/yggdrash-core/src/test/java/io/yggdrash/core/net/SimplePeerHandlerGroupTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/net/SimplePeerHandlerGroupTest.java
@@ -53,7 +53,7 @@ public class SimplePeerHandlerGroupTest {
 
     @Test
     public void getActivePeerListOf() {
-        assert peerHandlerGroup.getActivePeerListOf().size() == 0;
+        assert peerHandlerGroup.getActiveAddressList().size() == 0;
     }
 
     private void addPeerHandler() {

--- a/yggdrash-gateway/src/main/java/io/yggdrash/gateway/controller/PeerController.java
+++ b/yggdrash-gateway/src/main/java/io/yggdrash/gateway/controller/PeerController.java
@@ -46,7 +46,7 @@ class PeerController {
 
     @GetMapping("/channels")
     public ResponseEntity getChannels() {
-        return ResponseEntity.ok(peerHandlerGroup.getActivePeerListOf());
+        return ResponseEntity.ok(peerHandlerGroup.getActiveAddressList());
     }
 
     @GetMapping("/buckets")

--- a/yggdrash-node/src/main/java/io/yggdrash/node/NodeHealthIndicator.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/NodeHealthIndicator.java
@@ -87,7 +87,7 @@ public class NodeHealthIndicator implements HealthIndicator, NodeStatus {
                 .collect(Collectors.toMap(BlockChain::getBranchId, BlockChain::getLastIndex));
         builder.withDetail("branches", branches);
 
-        builder.withDetail("activePeers", peerHandlerGroup.getActivePeerList().size());
+        builder.withDetail("activePeers", peerHandlerGroup.handlerCount());
         health.set(builder.build());
     }
 }

--- a/yggdrash-node/src/test/java/io/yggdrash/node/GRpcTestNode.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/GRpcTestNode.java
@@ -1,13 +1,7 @@
 package io.yggdrash.node;
 
 import io.yggdrash.PeerTestUtils;
-import io.yggdrash.core.net.BootStrapNode;
-import io.yggdrash.core.net.DiscoveryConsumer;
-import io.yggdrash.core.net.DiscoveryServiceConsumer;
-import io.yggdrash.core.net.KademliaDiscovery;
-import io.yggdrash.core.net.PeerHandlerFactory;
-import io.yggdrash.core.net.PeerTable;
-import io.yggdrash.core.net.SimplePeerHandlerGroup;
+import io.yggdrash.core.net.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +26,7 @@ class GRpcTestNode extends BootStrapNode {
     }
 
     int getActivePeerCount() {
-        return peerHandlerGroup.getActivePeerList().size();
+        return peerHandlerGroup.handlerCount();
     }
 
     void logDebugging() {


### PR DESCRIPTION
handler가 동일한 address(ip:port)로 중복될 수 있어 handlerMap key를 peerId -> address로 변경하였습니다.