### PR TITLE
Change Protobuf type

### DIFF
--- a/yggdrash-contract-core/src/main/java/io/yggdrash/contract/core/store/OutputStore.java
+++ b/yggdrash-contract-core/src/main/java/io/yggdrash/contract/core/store/OutputStore.java
@@ -8,7 +8,7 @@ import java.util.Set;
 public interface OutputStore {
     String put(String schemeName, String id, JsonObject jsonObject);
 
-    String put(JsonObject blockJson);
+    void put(JsonObject blockJson);
 
     Set<String> put(long blockNo, Map<String, JsonObject> transactionMap);
 }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Block.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Block.java
@@ -19,6 +19,7 @@ package io.yggdrash.core.blockchain;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.util.Timestamps;
 import io.yggdrash.common.config.Constants;
 import io.yggdrash.common.crypto.ECKey;
 import io.yggdrash.common.crypto.HashUtil;
@@ -323,7 +324,7 @@ public class Block {
                 protoBlock.getHeader().getType().toByteArray(),
                 protoBlock.getHeader().getPrevBlockHash().toByteArray(),
                 protoBlock.getHeader().getIndex(),
-                protoBlock.getHeader().getTimestamp().getSeconds(),
+                Timestamps.toMillis(protoBlock.getHeader().getTimestamp()),
                 protoBlock.getHeader().getMerkleRoot().toByteArray(),
                 protoBlock.getHeader().getBodyLength()
         );

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Block.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Block.java
@@ -19,7 +19,6 @@ package io.yggdrash.core.blockchain;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Timestamp;
 import io.yggdrash.common.config.Constants;
 import io.yggdrash.common.crypto.ECKey;
 import io.yggdrash.common.crypto.HashUtil;
@@ -39,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.google.protobuf.util.Timestamps.fromMillis;
 import static io.yggdrash.common.config.Constants.EMPTY_BYTE32;
 import static io.yggdrash.common.config.Constants.TIMESTAMP_2018;
 
@@ -293,8 +293,7 @@ public class Block {
                 .setType(ByteString.copyFrom(block.getHeader().getType()))
                 .setPrevBlockHash(ByteString.copyFrom(block.getHeader().getPrevBlockHash()))
                 .setIndex(block.getHeader().getIndex())
-                .setTimestamp(Timestamp.newBuilder()
-                        .setSeconds(block.getHeader().getTimestamp()).build())
+                .setTimestamp(fromMillis(block.getHeader().getTimestamp()))
                 .setMerkleRoot(ByteString.copyFrom(block.getHeader().getMerkleRoot()))
                 .setBodyLength(block.getHeader().getBodyLength())
                 .build();

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Block.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Block.java
@@ -19,11 +19,11 @@ package io.yggdrash.core.blockchain;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
 import io.yggdrash.common.config.Constants;
 import io.yggdrash.common.crypto.ECKey;
 import io.yggdrash.common.crypto.HashUtil;
 import io.yggdrash.common.trie.Trie;
-import io.yggdrash.common.utils.ByteUtil;
 import io.yggdrash.core.exception.InvalidSignatureException;
 import io.yggdrash.core.exception.NotValidateException;
 import io.yggdrash.core.wallet.Wallet;
@@ -288,17 +288,16 @@ public class Block {
     public static Proto.Block toProtoBlock(Block block) {
         Proto.Block.Header protoHeader;
         protoHeader = Proto.Block.Header.newBuilder()
-            .setChain(ByteString.copyFrom(block.getHeader().getChain()))
-            .setVersion(ByteString.copyFrom(block.getHeader().getVersion()))
-            .setType(ByteString.copyFrom(block.getHeader().getType()))
-            .setPrevBlockHash(ByteString.copyFrom(block.getHeader().getPrevBlockHash()))
-            .setIndex(ByteString.copyFrom(ByteUtil.longToBytes(block.getHeader().getIndex())))
-            .setTimestamp(
-                    ByteString.copyFrom(ByteUtil.longToBytes(block.getHeader().getTimestamp())))
-            .setMerkleRoot(ByteString.copyFrom(block.getHeader().getMerkleRoot()))
-            .setBodyLength(
-                    ByteString.copyFrom(ByteUtil.longToBytes(block.getHeader().getBodyLength())))
-            .build();
+                .setChain(ByteString.copyFrom(block.getHeader().getChain()))
+                .setVersion(ByteString.copyFrom(block.getHeader().getVersion()))
+                .setType(ByteString.copyFrom(block.getHeader().getType()))
+                .setPrevBlockHash(ByteString.copyFrom(block.getHeader().getPrevBlockHash()))
+                .setIndex(block.getHeader().getIndex())
+                .setTimestamp(Timestamp.newBuilder()
+                        .setSeconds(block.getHeader().getTimestamp()).build())
+                .setMerkleRoot(ByteString.copyFrom(block.getHeader().getMerkleRoot()))
+                .setBodyLength(block.getHeader().getBodyLength())
+                .build();
 
         Proto.TransactionList.Builder builder = Proto.TransactionList.newBuilder();
         for (Transaction tx : block.getBody().getBody()) {
@@ -324,10 +323,10 @@ public class Block {
                 protoBlock.getHeader().getVersion().toByteArray(),
                 protoBlock.getHeader().getType().toByteArray(),
                 protoBlock.getHeader().getPrevBlockHash().toByteArray(),
-                ByteUtil.byteArrayToLong(protoBlock.getHeader().getIndex().toByteArray()),
-                ByteUtil.byteArrayToLong(protoBlock.getHeader().getTimestamp().toByteArray()),
+                protoBlock.getHeader().getIndex(),
+                protoBlock.getHeader().getTimestamp().getSeconds(),
                 protoBlock.getHeader().getMerkleRoot().toByteArray(),
-                ByteUtil.byteArrayToLong(protoBlock.getHeader().getBodyLength().toByteArray())
+                protoBlock.getHeader().getBodyLength()
         );
 
         List<Transaction> txList = new ArrayList<>();

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChain.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChain.java
@@ -256,7 +256,7 @@ public class BlockChain {
                 });
 
                 outputStores.forEach((storeType, store) -> {
-                    store.put(nextBlock.toJsonObject());
+                    store.put(nextBlock.toJsonObjectByProto());
                     store.put(nextBlock.getCoreBlock().getHeader().getIndex(), transactionMap);
                 });
             }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHeader.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHeader.java
@@ -241,10 +241,10 @@ public class BlockHeader {
                 protoBlockHeader.getVersion().toByteArray(),
                 protoBlockHeader.getType().toByteArray(),
                 protoBlockHeader.getPrevBlockHash().toByteArray(),
-                ByteUtil.byteArrayToLong(protoBlockHeader.getIndex().toByteArray()),
-                ByteUtil.byteArrayToLong(protoBlockHeader.getTimestamp().toByteArray()),
+                protoBlockHeader.getIndex(),
+                protoBlockHeader.getTimestamp().getSeconds(),
                 protoBlockHeader.getMerkleRoot().toByteArray(),
-                ByteUtil.byteArrayToLong(protoBlockHeader.getBodyLength().toByteArray())
+                protoBlockHeader.getBodyLength()
         );
 
         return blockHeader;

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHeader.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHeader.java
@@ -17,6 +17,7 @@
 package io.yggdrash.core.blockchain;
 
 import com.google.gson.JsonObject;
+import com.google.protobuf.util.Timestamps;
 import io.yggdrash.common.crypto.HashUtil;
 import io.yggdrash.common.crypto.HexUtil;
 import io.yggdrash.common.utils.ByteUtil;
@@ -236,17 +237,15 @@ public class BlockHeader {
 
     static BlockHeader toBlockHeader(Proto.Block.Header protoBlockHeader) {
 
-        BlockHeader blockHeader = new BlockHeader(
+        return new BlockHeader(
                 protoBlockHeader.getChain().toByteArray(),
                 protoBlockHeader.getVersion().toByteArray(),
                 protoBlockHeader.getType().toByteArray(),
                 protoBlockHeader.getPrevBlockHash().toByteArray(),
                 protoBlockHeader.getIndex(),
-                protoBlockHeader.getTimestamp().getSeconds(),
+                Timestamps.toMillis(protoBlockHeader.getTimestamp()),
                 protoBlockHeader.getMerkleRoot().toByteArray(),
                 protoBlockHeader.getBodyLength()
         );
-
-        return blockHeader;
     }
 }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHusk.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHusk.java
@@ -18,10 +18,10 @@ package io.yggdrash.core.blockchain;
 
 import com.google.gson.JsonObject;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
 import io.yggdrash.common.Sha3Hash;
 import io.yggdrash.common.trie.Trie;
 import io.yggdrash.common.util.TimeUtils;
-import io.yggdrash.common.utils.ByteUtil;
 import io.yggdrash.core.exception.NotValidateException;
 import io.yggdrash.core.wallet.Address;
 import io.yggdrash.core.wallet.Wallet;
@@ -149,8 +149,7 @@ public class BlockHusk implements ProtoHusk<Proto.Block>, Comparable<BlockHusk> 
     }
 
     public long getIndex() {
-
-        return ByteUtil.byteArrayToLong(this.protoBlock.getHeader().getIndex().toByteArray());
+        return this.protoBlock.getHeader().getIndex();
     }
 
     public List<TransactionHusk> getBody() {
@@ -230,10 +229,10 @@ public class BlockHusk implements ProtoHusk<Proto.Block>, Comparable<BlockHusk> 
                 .setVersion(ByteString.copyFrom(version))
                 .setType(ByteString.copyFrom(type))
                 .setPrevBlockHash(ByteString.copyFrom(prevBlockHash))
-                .setIndex(ByteString.copyFrom(ByteUtil.longToBytes(index)))
-                .setTimestamp(ByteString.copyFrom(ByteUtil.longToBytes(timestamp)))
+                .setIndex(index)
+                .setTimestamp(Timestamp.newBuilder().setSeconds(timestamp).build())
                 .setMerkleRoot(ByteString.copyFrom(merkleRoot))
-                .setBodyLength(ByteString.copyFrom(ByteUtil.longToBytes(bodyLength)))
+                .setBodyLength(bodyLength)
                 .build();
     }
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHusk.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHusk.java
@@ -17,8 +17,10 @@
 package io.yggdrash.core.blockchain;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Timestamp;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import io.yggdrash.common.Sha3Hash;
 import io.yggdrash.common.trie.Trie;
 import io.yggdrash.common.util.TimeUtils;
@@ -32,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import static com.google.protobuf.util.Timestamps.fromMillis;
 import static io.yggdrash.common.config.Constants.EMPTY_BYTE8;
 
 public class BlockHusk implements ProtoHusk<Proto.Block>, Comparable<BlockHusk> {
@@ -210,6 +213,17 @@ public class BlockHusk implements ProtoHusk<Proto.Block>, Comparable<BlockHusk> 
         return this.coreBlock.toJsonObject();
     }
 
+    JsonObject toJsonObjectByProto() {
+        try {
+            String print = JsonFormat.printer()
+                    .includingDefaultValueFields().print(this.protoBlock);
+            return new JsonParser().parse(print).getAsJsonObject();
+        } catch (InvalidProtocolBufferException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
     private Proto.Block.Header getHeader() {
         return this.protoBlock.getHeader();
     }
@@ -230,7 +244,7 @@ public class BlockHusk implements ProtoHusk<Proto.Block>, Comparable<BlockHusk> 
                 .setType(ByteString.copyFrom(type))
                 .setPrevBlockHash(ByteString.copyFrom(prevBlockHash))
                 .setIndex(index)
-                .setTimestamp(Timestamp.newBuilder().setSeconds(timestamp).build())
+                .setTimestamp(fromMillis(timestamp))
                 .setMerkleRoot(ByteString.copyFrom(merkleRoot))
                 .setBodyLength(bodyLength)
                 .build();

--- a/yggdrash-core/src/main/java/io/yggdrash/core/store/output/es/EsClient.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/store/output/es/EsClient.java
@@ -62,22 +62,23 @@ public class EsClient implements OutputStore {
     }
 
     @Override
-    public String put(JsonObject block) {
-        if (!eventSet.contains(blockIndex)) {
-            return null;
+    public void put(JsonObject block) {
+        if (!eventSet.contains(blockIndex) || block == null) {
+            return;
         }
         block.remove("body");
 
-        String id = String.valueOf(block.getAsJsonObject("header").get("index").getAsString());
+        String id = block.getAsJsonObject("header").get("index").getAsString();
         IndexResponse response = client.prepareIndex(blockIndex, "_doc", id)
                 .setSource(block.toString(), XContentType.JSON).get();
 
         switch (response.status()) {
             case OK:
             case CREATED:
-                return id;
+                return;
+            default:
+                log.warn("Failed save to elasticsearch");
         }
-        return null;
     }
 
     @Override

--- a/yggdrash-core/src/main/proto/Yggdrash.proto
+++ b/yggdrash-core/src/main/proto/Yggdrash.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 option java_package = "io.yggdrash.proto";
 option java_outer_classname = "Proto";
 
+import "google/protobuf/timestamp.proto";
 
 service Peer {
     rpc findPeers (TargetPeer) returns (PeerList) {
@@ -25,10 +26,10 @@ message Block {
         bytes version = 2;          // Version indicates message protocol version
         bytes type = 3;
         bytes prevBlockHash = 4;    // The hash of the previous block header
-        bytes index = 5;            // The index in the blockchain
-        bytes timestamp = 6;        // google.protobuf.Timestamp timestamp ?
+        uint64 index = 5;            // The index in the blockchain
+        google.protobuf.Timestamp timestamp = 6;        // google.protobuf.Timestamp timestamp ?
         bytes merkleRoot = 7;       // The hash of the BlockBody, by MerkleTree
-        bytes bodyLength = 8;
+        uint64 bodyLength = 8;
     }
 
     Header header = 1;

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BlockHuskTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BlockHuskTest.java
@@ -16,6 +16,7 @@
 
 package io.yggdrash.core.blockchain;
 
+import com.google.gson.JsonObject;
 import io.yggdrash.BlockChainTestUtils;
 import io.yggdrash.proto.Proto;
 import org.junit.Before;
@@ -69,5 +70,12 @@ public class BlockHuskTest {
         assertThat(genesisBlock.toJsonObject().toString()).isEqualTo(block2.toJsonObject().toString());
     }
 
-
+    @Test
+    public void testToJsonObjectFromProtoObject() {
+        JsonObject jsonObject = genesisBlock.toJsonObjectByProto();
+        String jsonString = jsonObject.toString();
+        assertThat(jsonObject).isNotNull();
+        assertThat(jsonObject.getAsJsonObject("header").get("index").getAsString()).isEqualTo("0");
+        assertThat(jsonString).startsWith("{");
+    }
 }

--- a/yggdrash-gateway/src/main/java/io/yggdrash/gateway/dto/BlockDto.java
+++ b/yggdrash-gateway/src/main/java/io/yggdrash/gateway/dto/BlockDto.java
@@ -55,7 +55,7 @@ public class BlockDto {
         blockDto.index = block.getIndex();
         blockDto.timestamp = ByteUtil.byteArrayToLong(header.getTimestamp().toByteArray());
         blockDto.merkleRoot = Hex.toHexString(header.getMerkleRoot().toByteArray());
-        blockDto.bodyLength = ByteUtil.byteArrayToLong(header.getBodyLength().toByteArray());
+        blockDto.bodyLength = header.getBodyLength();
         blockDto.signature = Hex.toHexString(block.getInstance().getSignature().toByteArray());
         blockDto.txSize = block.getBodyCount();
         if (withBody) {

--- a/yggdrash-gateway/src/main/java/io/yggdrash/gateway/dto/BlockDto.java
+++ b/yggdrash-gateway/src/main/java/io/yggdrash/gateway/dto/BlockDto.java
@@ -16,6 +16,7 @@
 
 package io.yggdrash.gateway.dto;
 
+import com.google.protobuf.util.Timestamps;
 import io.yggdrash.common.utils.ByteUtil;
 import io.yggdrash.core.blockchain.BlockHusk;
 import io.yggdrash.proto.Proto;
@@ -53,7 +54,7 @@ public class BlockDto {
         blockDto.type = Hex.toHexString(header.getType().toByteArray());
         blockDto.prevBlockId = Hex.toHexString(block.getPrevHash().getBytes());
         blockDto.index = block.getIndex();
-        blockDto.timestamp = ByteUtil.byteArrayToLong(header.getTimestamp().toByteArray());
+        blockDto.timestamp = Timestamps.toMillis(header.getTimestamp());
         blockDto.merkleRoot = Hex.toHexString(header.getMerkleRoot().toByteArray());
         blockDto.bodyLength = header.getBodyLength();
         blockDto.signature = Hex.toHexString(block.getInstance().getSignature().toByteArray());

--- a/yggdrash-node/src/main/java/io/yggdrash/node/service/BlockChainService.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/service/BlockChainService.java
@@ -90,8 +90,7 @@ public class BlockChainService extends BlockChainGrpc.BlockChainImplBase {
         return new StreamObserver<Proto.Block>() {
             @Override
             public void onNext(Proto.Block block) {
-                long id = ByteUtil.byteArrayToLong(
-                        block.getHeader().getIndex().toByteArray());
+                long id = block.getHeader().getIndex();
                 BlockHusk blockHusk = new BlockHusk(block);
                 log.debug("[BlockChainService] Received block: id=[{}], hash={}",
                         id, blockHusk.getHash());


### PR DESCRIPTION
프로토버퍼 내 byte 타입으로 되어있는 index, timestamp, bodyLength 에 타입 변경.
엘라스틱서치에 사용 가능한 데이터를 저장하기 위한 단계이며, 추후 Transaction 쪽도 변경이 필요.

프로토버퍼 파일 변경이 이루어졌으므로, clean 후 generateProto 과정이 필요