### PR TITLE
Return empty 32byte for empty block

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/common/trie/Trie.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/common/trie/Trie.java
@@ -8,6 +8,7 @@ import io.yggdrash.core.blockchain.TransactionHusk;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.yggdrash.common.config.Constants.EMPTY_BYTE32;
 import static io.yggdrash.common.crypto.HashUtil.HASH_256_ALGORITHM_NAME;
 
 /**
@@ -15,7 +16,6 @@ import static io.yggdrash.common.crypto.HashUtil.HASH_256_ALGORITHM_NAME;
  * <br> referenced <a href="https://github.com/bitcoinj"> bitcoinj </a>
  */
 public class Trie {
-    private static final byte[] EMPTY = new byte[0];
 
     private Trie() {
         throw new IllegalStateException("Utility class");
@@ -31,7 +31,7 @@ public class Trie {
     public static byte[] getMerkleRootHusk(List<TransactionHusk> txs) {
 
         if (txs == null || txs.isEmpty() || txs.contains(null)) {
-            return EMPTY;
+            return EMPTY_BYTE32;
         }
 
         List<byte[]> tree = new ArrayList<>();
@@ -52,7 +52,7 @@ public class Trie {
     public static byte[] getMerkleRoot(List<Transaction> txs) {
 
         if (txs == null || txs.isEmpty() || txs.contains(null)) {
-            return EMPTY;
+            return EMPTY_BYTE32;
         }
 
         List<byte[]> tree = new ArrayList<>();
@@ -78,15 +78,15 @@ public class Trie {
 
         try {
             if (hashTree == null || hashTree.contains(null)) {
-                return EMPTY;
+                return EMPTY_BYTE32;
             }
 
             treeSize = hashTree.size();
             if (treeSize == 0) {
-                return EMPTY;
+                return EMPTY_BYTE32;
             }
         } catch (Exception e) {
-            return EMPTY;
+            return EMPTY_BYTE32;
         }
 
         for (int levelSize = treeSize; levelSize > 1; levelSize = (levelSize + 1) / 2) {

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Block.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Block.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.google.protobuf.util.Timestamps.fromMillis;
-import static io.yggdrash.common.config.Constants.EMPTY_BYTE32;
 import static io.yggdrash.common.config.Constants.KEY.BODY;
 import static io.yggdrash.common.config.Constants.KEY.HEADER;
 import static io.yggdrash.common.config.Constants.KEY.SIGNATURE;
@@ -240,10 +239,7 @@ public class Block {
         check &= this.header.getTimestamp() > TIMESTAMP_2018;
         check &= !(this.header.getBodyLength() < 0
                 || this.header.getBodyLength() != this.getBody().length());
-        check &= Arrays.equals(
-                Arrays.equals(this.header.getMerkleRoot(),
-                        EMPTY_BYTE32) ? null : this.header.getMerkleRoot(),
-                Trie.getMerkleRoot(this.body.getBody()));
+        check &= Arrays.equals(this.header.getMerkleRoot(), Trie.getMerkleRoot(this.body.getBody()));
 
         return check;
     }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockBody.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockBody.java
@@ -27,8 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import static io.yggdrash.common.config.Constants.EMPTY_BYTE32;
-
 public class BlockBody {
 
     private static final int TX_HEADER_LENGTH = 84;
@@ -113,8 +111,7 @@ public class BlockBody {
     }
 
     public byte[] getMerkleRoot() {
-        byte[] merkleRoot = Trie.getMerkleRoot(this.body);
-        return merkleRoot == null ? EMPTY_BYTE32 : merkleRoot;
+        return Trie.getMerkleRoot(this.body);
     }
 
     /**

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHusk.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockHusk.java
@@ -82,9 +82,6 @@ public class BlockHusk implements ProtoHusk<Proto.Block>, Comparable<BlockHusk> 
         }
 
         byte[] merkleRoot = Trie.getMerkleRootHusk(body);
-        if (merkleRoot == null) {
-            merkleRoot = EMPTY_BYTE;
-        }
 
         long length = 0;
 

--- a/yggdrash-core/src/test/java/io/yggdrash/common/trie/TrieTests.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/common/trie/TrieTests.java
@@ -11,6 +11,7 @@ import org.spongycastle.util.encoders.Hex;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.yggdrash.common.config.Constants.EMPTY_BYTE32;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -60,13 +61,13 @@ public class TrieTests {
         // 3. test with tx 0
         txsList = new ArrayList<>();
         merkleRoot = Trie.getMerkleRootHusk(txsList);
-        assertEquals(0, merkleRoot.length);
+        assertEquals(EMPTY_BYTE32.length, merkleRoot.length);
 
         log.debug("MerkleRoot with tx 0 = null");
 
         // 4. test with tx null
         merkleRoot = Trie.getMerkleRootHusk(null);
-        assertEquals(0, merkleRoot.length);
+        assertEquals(EMPTY_BYTE32.length, merkleRoot.length);
 
         log.debug("MerkleRoot with tx null = null");
 
@@ -78,7 +79,7 @@ public class TrieTests {
 
         txsList.add(null);
         merkleRoot = Trie.getMerkleRootHusk(txsList);
-        assertEquals(0, merkleRoot.length);
+        assertEquals(EMPTY_BYTE32.length, merkleRoot.length);
     }
 
     @Test

--- a/yggdrash-core/src/test/java/io/yggdrash/common/trie/TrieTests.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/common/trie/TrieTests.java
@@ -12,8 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.yggdrash.common.config.Constants.EMPTY_BYTE32;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class TrieTests {
 
@@ -46,7 +47,7 @@ public class TrieTests {
 
         byte[] merkleRoot;
         merkleRoot = Trie.getMerkleRootHusk(txsList);
-        assertNotNull(merkleRoot);
+        assertThat(merkleRoot).isNotEqualTo(EMPTY_BYTE32);
 
         log.debug("MerkleRoot with tx 7=" + Hex.toHexString(merkleRoot));
 
@@ -54,32 +55,27 @@ public class TrieTests {
         txsList = new ArrayList<>();
         txsList.add(this.tx1);
         merkleRoot = Trie.getMerkleRootHusk(txsList);
-        assertNotNull(merkleRoot);
+        assertThat(merkleRoot).isNotEqualTo(EMPTY_BYTE32);
 
         log.debug("MerkleRoot with tx 1=" + Hex.toHexString(merkleRoot));
 
         // 3. test with tx 0
         txsList = new ArrayList<>();
         merkleRoot = Trie.getMerkleRootHusk(txsList);
-        assertEquals(EMPTY_BYTE32.length, merkleRoot.length);
+        assertArrayEquals(EMPTY_BYTE32, merkleRoot);
 
         log.debug("MerkleRoot with tx 0 = null");
 
         // 4. test with tx null
         merkleRoot = Trie.getMerkleRootHusk(null);
-        assertEquals(EMPTY_BYTE32.length, merkleRoot.length);
+        assertArrayEquals(EMPTY_BYTE32, merkleRoot);
 
         log.debug("MerkleRoot with tx null = null");
 
         // 5. null list Test
-        txsList.add(this.tx1);
-        txsList.add(this.tx2);
-        merkleRoot = Trie.getMerkleRootHusk(txsList);
-        assertNotNull(merkleRoot);
-
         txsList.add(null);
         merkleRoot = Trie.getMerkleRootHusk(txsList);
-        assertEquals(EMPTY_BYTE32.length, merkleRoot.length);
+        assertArrayEquals(EMPTY_BYTE32, merkleRoot);
     }
 
     @Test

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BlockTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BlockTest.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -95,6 +96,17 @@ public class BlockTest {
 
         BlockSignature blockSig = new BlockSignature(wallet, blockHeader.getHashForSigning());
         block1 = new Block(blockHeader, blockSig.getSignature(), blockBody1);
+    }
+
+    @Test
+    public void testEmptyBlockVerify() {
+        BlockBody blockBody = new BlockBody(Collections.emptyList());
+        BlockHeader blockHeader = new BlockHeader(
+                chain, version, type, prevBlockHash, 0, TimeUtils.time(),
+                blockBody.getMerkleRoot(), blockBody.length());
+        BlockSignature blockSig = new BlockSignature(wallet, blockHeader.getHashForSigning());
+        Block emptyBlock = new Block(blockHeader, blockSig.getSignature(), blockBody);
+        assertThat(emptyBlock.verify()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
빈 블럭에 대해서 32byte의 empty 32 byte 를 리턴해서 블럭 생성시 null 체크를 하지 않도록 수정했습니다.