### PR TITLE
Add block header serialization test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ project(':yggdrash-core') {
         compile "org.elasticsearch.client:transport:${esVersion}"
         compileOnly "javax.annotation:javax.annotation-api:${annotationVersion}"
         testCompile "org.assertj:assertj-core:${assertjVersion}"
+        testCompile "org.mongodb:bson:3.10.1"
     }
 
     protobuf {

--- a/yggdrash-core/src/main/java/io/yggdrash/common/config/Constants.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/common/config/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
     public static final byte[] EMPTY_BYTE8 = new byte[8];
     public static final byte[] EMPTY_BYTE20 = new byte[20];
     public static final byte[] EMPTY_BYTE32 = new byte[32];
+    public static final byte[] EMPTY_BYTE65 = new byte[65];
     public static final byte[] EMPTY_BYTE1K = new byte[1024];
     public static final byte[] EMPTY_BYTE10K = new byte[10240];
     public static final byte[] EMPTY_BYTE100K = new byte[102400];

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/TransactionBuilder.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/TransactionBuilder.java
@@ -26,6 +26,8 @@ import io.yggdrash.core.wallet.Wallet;
 import java.util.LinkedList;
 import java.util.List;
 
+import static io.yggdrash.common.config.Constants.EMPTY_BYTE65;
+
 public class TransactionBuilder {
     private BranchId branchId;
     private Wallet wallet;
@@ -112,7 +114,7 @@ public class TransactionBuilder {
         txHeader = new TransactionHeader(chain, version, type, timestamp, transactionBody);
 
         try {
-            byte[] sign = new byte[]{};
+            byte[] sign = EMPTY_BYTE65;
             if (wallet != null) {
                 TransactionSignature txSig;
                 txSig = new TransactionSignature(wallet, txHeader.getHashForSigning());

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/genesis/GenesisBlock.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/genesis/GenesisBlock.java
@@ -14,6 +14,10 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 
+import static io.yggdrash.common.config.Constants.EMPTY_BYTE32;
+import static io.yggdrash.common.config.Constants.EMPTY_BYTE65;
+import static io.yggdrash.common.config.Constants.EMPTY_BYTE8;
+
 public class GenesisBlock {
     private final BlockHusk block;
     private final Branch branch;
@@ -77,14 +81,14 @@ public class GenesisBlock {
 
         BlockHeader blockHeader = new BlockHeader(
                 branch.getBranchId().getBytes(),
-                new byte[8],
-                new byte[8],
-                new byte[32],
+                EMPTY_BYTE8,
+                EMPTY_BYTE8,
+                EMPTY_BYTE32,
                 0L,
                 branch.getTimestamp(),
                 blockBody.getMerkleRoot(),
                 blockBody.length());
-        return new Block(blockHeader, new byte[]{}, blockBody);
+        return new Block(blockHeader, EMPTY_BYTE65, blockBody);
     }
 
 

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BlockHeaderSerializeTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BlockHeaderSerializeTest.java
@@ -1,0 +1,151 @@
+package io.yggdrash.core.blockchain;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import io.yggdrash.BlockChainTestUtils;
+import io.yggdrash.TestConstants;
+import io.yggdrash.common.exception.FailedOperationException;
+import io.yggdrash.common.utils.ByteUtil;
+import io.yggdrash.proto.Proto;
+import org.bson.BSONObject;
+import org.bson.BasicBSONDecoder;
+import org.bson.BasicBSONEncoder;
+import org.bson.BasicBSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
+
+public class BlockHeaderSerializeTest extends TestConstants.PerformanceTest {
+    private static final Logger log = LoggerFactory.getLogger(BlockHeaderSerializeTest.class);
+    private static final int MAX_TEST_NUM = 1000000;
+    private Block genesis;
+
+    @Before
+    public void setUp() {
+        this.genesis = BlockChainTestUtils.genesisBlock().getCoreBlock();
+    }
+
+    @Test(timeout = 1000L)
+    public void testCoreBlock() {
+        BlockHeader blockHeader = genesis.getHeader();
+
+        byte[] binary = blockHeader.toBinary();
+        log.info("CoreBlock toBinary().length={}, toString()={}", binary.length, blockHeader);
+        Assert.assertEquals(blockHeader, new BlockHeader(binary));
+
+        // to binary test
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < MAX_TEST_NUM; i++) {
+            blockHeader.toBinary();
+        }
+        long totalMilllis = System.currentTimeMillis() - startTime;
+        log.info("CoreBlock toBinary() count={}, time={}", MAX_TEST_NUM, totalMilllis);
+
+        // to object test
+        startTime = System.currentTimeMillis();
+        for (int i = 0; i < MAX_TEST_NUM; i++) {
+            new BlockHeader(binary);
+        }
+        totalMilllis = System.currentTimeMillis() - startTime;
+        log.info("CoreBlock toObject() count={}, time={}", MAX_TEST_NUM, totalMilllis);
+    }
+
+    @Test(timeout = 1000L)
+    public void testProtoBlock() {
+        Proto.Block.Header blockHeader = genesis.toProtoBlock().getHeader();
+
+        byte[] binary = blockHeader.toByteArray();
+        log.info("ProtoBlock toBinary().length={}, toString()={}", binary.length, toJson(blockHeader));
+        Assert.assertEquals(blockHeader, parseFrom(binary));
+
+        // to binary test
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < MAX_TEST_NUM; i++) {
+            blockHeader.toByteArray();
+        }
+        long totalMilllis = System.currentTimeMillis() - startTime;
+        log.info("ProtoBlock toBinary() count={}, time={}", MAX_TEST_NUM, totalMilllis);
+
+        // to object test
+        startTime = System.currentTimeMillis();
+        for (int i = 0; i < MAX_TEST_NUM; i++) {
+            parseFrom(binary);
+        }
+        totalMilllis = System.currentTimeMillis() - startTime;
+        log.info("ProtoBlock toObject() count={}, time={}", MAX_TEST_NUM, totalMilllis);
+    }
+
+    @Test
+    public void testBsonBlock() {
+        BSONObject blockHeader = toBlockHeaderBson(genesis.getHeader());
+
+        byte[] binary = new BasicBSONEncoder().encode(blockHeader);
+        log.info("BsonBlock toBinary().length={}, toString()={}", binary.length, blockHeader);
+        Assert.assertEquals(blockHeader, new BasicBSONDecoder().readObject(binary));
+
+        // to binary test
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < MAX_TEST_NUM; i++) {
+            new BasicBSONEncoder().encode(blockHeader);
+        }
+        long totalMilllis = System.currentTimeMillis() - startTime;
+        log.info("BsonBlock toBinary() count={}, time={}", MAX_TEST_NUM, totalMilllis);
+
+        // to object test
+        startTime = System.currentTimeMillis();
+        for (int i = 0; i < MAX_TEST_NUM; i++) {
+            new BasicBSONDecoder().readObject(binary);
+        }
+        totalMilllis = System.currentTimeMillis() - startTime;
+        log.info("BsonBlock toObject() count={}, time={}", MAX_TEST_NUM, totalMilllis);
+    }
+
+    private Proto.Block.Header parseFrom(byte[] data) {
+        try {
+            return Proto.Block.Header.parseFrom(data);
+        } catch (Exception e) {
+            throw new FailedOperationException(e);
+        }
+    }
+
+    private static BSONObject toBlockHeaderBson(BlockHeader blockHeader) {
+        BSONObject bsonObject = new BasicBSONObject();
+
+        bsonObject.put("chain", blockHeader.getChain());
+        bsonObject.put("version", blockHeader.getVersion());
+        bsonObject.put("type", blockHeader.getType());
+        bsonObject.put("prevBlockHash", blockHeader.getPrevBlockHash());
+        bsonObject.put("index", ByteUtil.longToBytes(blockHeader.getIndex()));
+        bsonObject.put("timestamp", ByteUtil.longToBytes(blockHeader.getTimestamp()));
+        bsonObject.put("merkleRoot", blockHeader.getMerkleRoot());
+        bsonObject.put("bodyLength", ByteUtil.longToBytes(blockHeader.getBodyLength()));
+        return bsonObject;
+    }
+
+    private static BSONObject toBlockHeaderHexBson(BlockHeader blockHeader) {
+        BSONObject bsonObject = new BasicBSONObject();
+
+        bsonObject.put("chain", Hex.toHexString(blockHeader.getChain()));
+        bsonObject.put("version", Hex.toHexString(blockHeader.getVersion()));
+        bsonObject.put("type", Hex.toHexString(blockHeader.getType()));
+        bsonObject.put("prevBlockHash", Hex.toHexString(blockHeader.getPrevBlockHash()));
+        bsonObject.put("index", Hex.toHexString(ByteUtil.longToBytes(blockHeader.getIndex())));
+        bsonObject.put("timestamp", Hex.toHexString(ByteUtil.longToBytes(blockHeader.getTimestamp())));
+        bsonObject.put("merkleRoot", Hex.toHexString(blockHeader.getMerkleRoot()));
+        bsonObject.put("bodyLength", Hex.toHexString(ByteUtil.longToBytes(blockHeader.getBodyLength())));
+        return bsonObject;
+    }
+
+    private JsonElement toJson(Proto.Block.Header blockHeader) {
+        try {
+            return new JsonParser().parse(JsonFormat.printer().print(blockHeader));
+        } catch (InvalidProtocolBufferException e) {
+            throw new FailedOperationException(e);
+        }
+    }
+}


### PR DESCRIPTION
Proto, Bson, Core BlockHeader에 대한 Serialization 테스트를 추가하였습니다.

Size(Byte):
Core(124), Proto(127), Bson(248)

Performance(100만건, ms):
- Proto: toBinary(186), toObject(248)
- Core: toBinary(276), toObject(147)
- Bson: toBinary(1737), toObject(1398)