### PR TITLE
Feature/remove leveldb getall

### DIFF
--- a/yggdrash-common/src/main/java/io/yggdrash/common/config/Constants.java
+++ b/yggdrash-common/src/main/java/io/yggdrash/common/config/Constants.java
@@ -1,6 +1,8 @@
 package io.yggdrash.common.config;
 
 import io.yggdrash.common.contract.ContractVersion;
+import io.yggdrash.common.crypto.HashUtil;
+import io.yggdrash.common.utils.SerializationUtil;
 
 public final class Constants {
 
@@ -11,11 +13,6 @@ public final class Constants {
     public static final int BRANCH_LENGTH = 20;
     public static final int BRANCH_HEX_LENGTH = BRANCH_LENGTH * 2;
 
-    /*
-    private static final String STEM = "STEM"; //isSystem = false
-    private static final String YEED = "YEED"; //isSystem = true
-    public static final String VALIDATOR = "VALIDATOR"; //isSystem = true
-    */
     public static final String YGGDRASH = "YGGDRASH";
     public static final String BRANCH_ID = "branchId";
     public static final String TX_ID = "txId";
@@ -28,7 +25,7 @@ public final class Constants {
     public static final int HASH_LENGTH = 32;
     public static final int SIGNATURE_LENGTH = 65;
 
-    public static final int TX_BODY_MAX_LENGTH = 10000000; // 10 Mb
+    public static final byte[] LEVELDB_SIZE_KEY = HashUtil.sha3(SerializationUtil.serializeString("SIZE"));
 
     public static final byte[] EMPTY_BRANCH = new byte[BRANCH_LENGTH];
     public static final byte[] EMPTY_HASH = new byte[HASH_LENGTH];
@@ -74,7 +71,6 @@ public final class Constants {
         public static final String HEADER = "header";
         public static final String SIGNATURE = "signature";
         public static final String BODY = "body";
-        public static final String VALIDATOR = "validator";
     }
 
     private static final String STEM_CONTRACT_STR = "74df17611373672371cb3872e8a5d4a2e8733fb1";
@@ -82,7 +78,4 @@ public final class Constants {
 
     private static final String YEED_CONTRACT_STR = "d79ab8e1d735090d2a7ef4f16d13a910457c0d93";
     public static final ContractVersion YEED_CONTRACT_VERSION = ContractVersion.ofNonHex(YEED_CONTRACT_STR);
-
-    private static final String VALIDATOR_CONTRACT_STR = "f5f92857982260477387d519f020b6b1fe37b2d5";
-    public static final ContractVersion VALIDATOR_CONTRACT_VERSION = ContractVersion.ofNonHex(VALIDATOR_CONTRACT_STR);
 }

--- a/yggdrash-common/src/main/java/io/yggdrash/common/store/datasource/DbSource.java
+++ b/yggdrash-common/src/main/java/io/yggdrash/common/store/datasource/DbSource.java
@@ -18,9 +18,6 @@ package io.yggdrash.common.store.datasource;
 
 import org.iq80.leveldb.Options;
 
-import java.io.IOException;
-import java.util.List;
-
 public interface DbSource<K, V> {
     DbSource<K, V> init();
 
@@ -29,8 +26,6 @@ public interface DbSource<K, V> {
     V get(K key);
 
     void put(K key, V value);
-
-    List<V> getAll() throws IOException;
 
     void close();
 

--- a/yggdrash-common/src/main/java/io/yggdrash/common/store/datasource/HashMapDbSource.java
+++ b/yggdrash-common/src/main/java/io/yggdrash/common/store/datasource/HashMapDbSource.java
@@ -19,8 +19,6 @@ package io.yggdrash.common.store.datasource;
 import org.apache.commons.codec.binary.Hex;
 import org.iq80.leveldb.Options;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -47,11 +45,6 @@ public class HashMapDbSource implements DbSource<byte[], byte[]> {
     @Override
     public void put(byte[] key, byte[] value) {
         db.put(Hex.encodeHexString(key), value);
-    }
-
-    @Override
-    public List<byte[]> getAll() {
-        return new ArrayList<>(db.values());
     }
 
     @Override

--- a/yggdrash-common/src/main/java/io/yggdrash/common/store/datasource/LevelDbDataSource.java
+++ b/yggdrash-common/src/main/java/io/yggdrash/common/store/datasource/LevelDbDataSource.java
@@ -19,7 +19,6 @@ package io.yggdrash.common.store.datasource;
 import io.yggdrash.common.exception.FailedOperationException;
 import io.yggdrash.common.utils.FileUtil;
 import org.iq80.leveldb.DB;
-import org.iq80.leveldb.DBIterator;
 import org.iq80.leveldb.Options;
 import org.iq80.leveldb.WriteBatch;
 import org.iq80.leveldb.impl.Iq80DBFactory;
@@ -30,8 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -174,14 +171,4 @@ public class LevelDbDataSource implements DbSource<byte[], byte[]> {
         return alive;
     }
 
-    public List<byte[]> getAll() throws IOException {
-        List<byte[]> valueList = new ArrayList<>();
-        try (DBIterator iterator = db.iterator()) {
-            for (iterator.seekToFirst(); iterator.hasNext(); iterator.next()) {
-                byte[] value = iterator.peekNext().getValue();
-                valueList.add(value);
-            }
-        }
-        return valueList;
-    }
 }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/p2p/KademliaPeerTable.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/p2p/KademliaPeerTable.java
@@ -41,7 +41,7 @@ public class KademliaPeerTable implements PeerTable {
     }
 
     @Override
-    public void loadSeedNodes(List<String> seedPeerList) {
+    public void loadSeedPeers(List<String> seedPeerList) {
         if (this.peerStore.size() > 0) {
             for (String peer : this.peerStore.getAll()) {
                 addPeer(Peer.valueOf(peer));
@@ -79,7 +79,7 @@ public class KademliaPeerTable implements PeerTable {
     }
 
     @Override
-    public void copyLiveNode(long minTableTime) {
+    public void copyLivePeer(long minTableTime) {
         List<Peer> peerList = new ArrayList<>();
         long baseTime = System.currentTimeMillis();
         for (Peer peer : getAllPeers()) {

--- a/yggdrash-core/src/main/java/io/yggdrash/core/p2p/KademliaPeerTableGroup.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/p2p/KademliaPeerTableGroup.java
@@ -108,7 +108,7 @@ public class KademliaPeerTableGroup implements PeerTableGroup {
     @Override
     public void copyLiveNode() {
         long minTableTime = 30000;      //30 seconds
-        tableMap.values().forEach(table -> table.copyLiveNode(minTableTime));
+        tableMap.values().forEach(table -> table.copyLivePeer(minTableTime));
     }
 
     @Override
@@ -119,7 +119,7 @@ public class KademliaPeerTableGroup implements PeerTableGroup {
     }
 
     private void selfRefresh(Map.Entry<BranchId, PeerTable> entry) {
-        entry.getValue().loadSeedNodes(seedPeerList);
+        entry.getValue().loadSeedPeers(seedPeerList);
         lookup(0, new ArrayList<>(), getOwner(), entry);
     }
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/p2p/PeerTable.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/p2p/PeerTable.java
@@ -21,11 +21,11 @@ import java.util.Map;
 
 public interface PeerTable {
 
-    void loadSeedNodes(List<String> seedPeerList);
+    void loadSeedPeers(List<String> seedPeerList);
 
     void addPeer(Peer peer);
 
-    void copyLiveNode(long minTableTime);
+    void copyLivePeer(long minTableTime);
 
     List<Peer> getClosestPeers(Peer peer, int limit); // getNeighbor
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/store/ConsensusBlockStore.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/store/ConsensusBlockStore.java
@@ -27,7 +27,4 @@ public interface ConsensusBlockStore<T> extends ReadWriterStore<Sha3Hash, Consen
     void addBlock(ConsensusBlock<T> block);
 
     ConsensusBlock<T> getBlockByIndex(long index);
-
-    long getBlockChainTransactionSize();
-
 }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/store/PeerStore.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/store/PeerStore.java
@@ -16,62 +16,71 @@
 
 package io.yggdrash.core.store;
 
+import io.yggdrash.common.crypto.HashUtil;
 import io.yggdrash.common.store.datasource.DbSource;
+import io.yggdrash.common.utils.ByteUtil;
+import io.yggdrash.common.utils.SerializationUtil;
 import io.yggdrash.contract.core.store.ReadWriterStore;
+import io.yggdrash.core.exception.NonExistObjectException;
 import io.yggdrash.core.p2p.Peer;
 import io.yggdrash.core.p2p.PeerId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
-import java.io.IOException;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class PeerStore implements ReadWriterStore<PeerId, Peer> {
 
-    private static final Logger log = LoggerFactory.getLogger(PeerStore.class);
+    private static final byte[] TOTAL_SIZE = SerializationUtil.serializeString("TOTAL_SIZE");
+
     private final DbSource<byte[], byte[]> db;
-    private final Map<PeerId, Peer> peers = new HashMap<>();
+    private long peerSize;
 
     PeerStore(DbSource<byte[], byte[]> dbSource) {
         this.db = dbSource.init();
+        this.peerSize = loadPeerSize();
     }
 
     @Override
     public void put(PeerId key, Peer value) {
-        peers.put(key, value);
+        if (!contains(key)) {
+            peerSize++;
+            byte[] indexKey = getIndexKey(peerSize);
+            // store peer index
+            db.put(indexKey, key.getBytes());
+            db.put(TOTAL_SIZE, ByteUtil.longToBytes(peerSize));
+        }
         db.put(key.getBytes(), value.toString().getBytes());
-    }
-
-    private void put(Peer value) {
-        put(value.getPeerId(), value);
     }
 
     @Override
     public Peer get(PeerId key) {
-        byte[] foundedValue = db.get(key.getBytes());
+        return get(key.getBytes());
+    }
+
+    private Peer get(byte[] key) {
+        byte[] foundedValue = db.get(key);
         if (foundedValue != null) {
             return Peer.valueOf(foundedValue);
         }
-        return peers.get(key);
+        throw new NonExistObjectException(Hex.toHexString(key));
     }
 
     @Override
     public boolean contains(PeerId key) {
-        if (db.get(key.getBytes()) != null) {
-            return true;
-        }
-        return peers.containsKey(key);
+        return db.get(key.getBytes()) != null;
     }
 
     public void overwrite(List<Peer> peerList) {
-
-        peers.keySet().stream().map(PeerId::getBytes).forEach(db::delete);
-        peers.keySet().removeIf(peers::containsKey);
-
-        peerList.forEach(this::put);
+        // remove all
+        for (int i = 1; i <= peerSize; i++) {
+            byte[] indexKey = getIndexKey(i);
+            byte[] key = db.get(indexKey);
+            db.delete(key);
+        }
+        peerSize = 0L;
+        // put all
+        peerList.forEach(peer -> put(peer.getPeerId(), peer));
     }
 
     public void close() {
@@ -79,30 +88,50 @@ public class PeerStore implements ReadWriterStore<PeerId, Peer> {
     }
 
     public void remove(PeerId key) {
-        peers.remove(key);
+        byte[] foundedValue = db.get(key.getBytes());
+        if (foundedValue == null) {
+            return;
+        }
+        byte[] indexKey = getIndexKey(peerSize);
+        db.delete(indexKey);
         db.delete(key.getBytes());
+        peerSize--;
+        db.put(TOTAL_SIZE, ByteUtil.longToBytes(peerSize));
     }
 
     public List<String> getAll() {
-        try {
-            if (!db.getAll().isEmpty()) {
-                return db.getAll().stream().map(Peer::valueOf)
-                        .map(Peer::toString).collect(Collectors.toList());
-            }
-        } catch (IOException e) {
-            log.error(e.getMessage());
+        List<String> list = new ArrayList<>();
+        if (peerSize == 0) {
+            return list;
         }
-        return peers.values().stream().map(Peer::toString).collect(Collectors.toList());
+
+        for (int i = 1; i <= peerSize; i++) {
+            byte[] indexKey = getIndexKey(i);
+            byte[] key = db.get(indexKey);
+            Peer peer = get(key);
+            list.add(peer.getYnodeUri());
+        }
+        return list;
     }
 
-    public int size() {
-        try {
-            if (!db.getAll().isEmpty()) {
-                return db.getAll().size();
-            }
-        } catch (IOException e) {
-            log.error(e.getMessage());
+    public long size() {
+        return peerSize;
+    }
+
+    private long loadPeerSize() {
+        if (peerSize > 0L) {
+            return peerSize;
         }
-        return peers.size();
+        // loading db is just first
+        byte[] sizeByte = db.get(TOTAL_SIZE);
+        if (sizeByte != null) {
+            return ByteUtil.byteArrayToLong(sizeByte);
+        }
+        return peerSize;
+    }
+
+    private byte[] getIndexKey(long index) {
+        String blockIndexKey = "PEER_INDEX_" + index;
+        return HashUtil.sha3(blockIndexKey.getBytes());
     }
 }

--- a/yggdrash-core/src/test/java/io/yggdrash/core/p2p/PeerTableGroupTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/p2p/PeerTableGroupTest.java
@@ -34,7 +34,7 @@ public class PeerTableGroupTest {
     /*
     Try refresh with TARGET
     The size of closestPeers will be 0, so selfRefresh will be executed.
-    selfLookup is done after loadSeedNodes.
+    selfLookup is done after loadSeedPeers.
     lookup will proceed with the target after selfRefresh done.
     A total of 13 peers will be existed in the bucket which includes 6 peers received after lookup,
     5 peers received after lookup by target, owner, and seed.

--- a/yggdrash-core/src/test/java/io/yggdrash/core/p2p/PeerTableTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/p2p/PeerTableTest.java
@@ -80,7 +80,7 @@ public class PeerTableTest {
         List<Peer> latestPeerList = peerTable.getLatestPeers(touchedTime);
 
         assertEquals(1, latestPeerList.size());
-        assertTrue(!latestPeerList.contains(peer1));
+        assertFalse(latestPeerList.contains(peer1));
         assertTrue(latestPeerList.contains(peer2));
     }
 
@@ -116,13 +116,13 @@ public class PeerTableTest {
 
         // act
         Utils.sleep(10);
-        peerTable.copyLiveNode(5);
+        peerTable.copyLivePeer(5);
 
         // assert
         assertEquals(0, peerTable.getPeerStore().size());
 
         // act
-        peerTable.copyLiveNode(500);
+        peerTable.copyLivePeer(500);
         // assert
         assertEquals(2, peerTable.getPeerStore().size());
 
@@ -137,7 +137,7 @@ public class PeerTableTest {
 
         // act
         Utils.sleep(10);
-        peerTable.copyLiveNode(15);
+        peerTable.copyLivePeer(15);
 
         //assert
         assertEquals(3, peerTable.getPeerStore().size());

--- a/yggdrash-core/src/test/java/io/yggdrash/core/store/BlockStoreTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/store/BlockStoreTest.java
@@ -21,25 +21,50 @@ import io.yggdrash.StoreTestUtils;
 import io.yggdrash.common.store.datasource.LevelDbDataSource;
 import io.yggdrash.core.consensus.ConsensusBlock;
 import io.yggdrash.proto.PbftProto;
-import org.assertj.core.api.Assertions;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class BlockStoreTest {
+    private ConsensusBlockStore<PbftProto.PbftBlock> blockStore;
+
+    @Before
+    public void setUp() {
+        LevelDbDataSource ds = new LevelDbDataSource(StoreTestUtils.getTestPath(), "block-store-test");
+        blockStore = new PbftBlockStoreMock(ds);
+    }
 
     @After
     public void tearDown() {
+        blockStore.close();
         StoreTestUtils.clearTestDb();
     }
 
     @Test
     public void shouldBeGotBlock() {
-        LevelDbDataSource ds = new LevelDbDataSource(StoreTestUtils.getTestPath(), "block-store-test");
-        PbftBlockStoreMock blockStore = new PbftBlockStoreMock(ds);
+        // arrange
         ConsensusBlock<PbftProto.PbftBlock> block = BlockChainTestUtils.genesisBlock();
+        // act
         blockStore.put(block.getHash(), block);
+        // assert
+        assertThat(blockStore.contains(block.getHash())).isTrue();
         ConsensusBlock<PbftProto.PbftBlock> foundBlock = blockStore.get(block.getHash());
-        Assertions.assertThat(foundBlock).isEqualTo(block);
-        Assertions.assertThat(blockStore.get(foundBlock.getHash())).isEqualTo(foundBlock);
+        assertThat(foundBlock).isEqualTo(block);
+        assertThat(blockStore.size()).isEqualTo(1L);
+    }
+
+    @Test
+    public void shouldBeGotBlockByIndex() {
+        // arrange
+        ConsensusBlock<PbftProto.PbftBlock> block = BlockChainTestUtils.genesisBlock();
+        // act
+        blockStore.addBlock(block);
+        // assert
+        assertThat(blockStore.contains(block.getHash())).isTrue();
+        ConsensusBlock<PbftProto.PbftBlock> foundBlock = blockStore.getBlockByIndex(block.getIndex());
+        assertThat(foundBlock).isEqualTo(block);
+        assertThat(blockStore.size()).isEqualTo(1L);
     }
 }

--- a/yggdrash-core/src/test/java/io/yggdrash/core/store/PeerStoreTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/store/PeerStoreTest.java
@@ -21,6 +21,7 @@ import io.yggdrash.common.store.datasource.HashMapDbSource;
 import io.yggdrash.common.store.datasource.LevelDbDataSource;
 import io.yggdrash.core.p2p.Peer;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -33,6 +34,11 @@ import static org.junit.Assert.assertTrue;
 
 public class PeerStoreTest {
     private PeerStore peerStore;
+
+    @Before
+    public void setUp() {
+        peerStore = new PeerStore(new HashMapDbSource());
+    }
 
     @AfterClass
     public static void destroy() {
@@ -54,17 +60,32 @@ public class PeerStoreTest {
 
     @Test
     public void shouldBeGotAllPeer() {
-        peerStore = new PeerStore(new HashMapDbSource());
-
         Peer peer = Peer.valueOf("ynode://75bff16c@127.0.0.1:32918");
+        peerStore.put(peer.getPeerId(), peer);
+        assertThat(peerStore.getAll().size()).isEqualTo(1);
+
+        // add exist peer
         peerStore.put(peer.getPeerId(), peer);
         assertThat(peerStore.getAll().size()).isEqualTo(1);
     }
 
+
+    @Test
+    public void shouldBeRemovedPeer() {
+        // arrange
+        Peer peer = Peer.valueOf("ynode://75bff16c@127.0.0.1:32918");
+        peerStore.put(peer.getPeerId(), peer);
+        assertThat(peerStore.size()).isEqualTo(1);
+        assertThat(peerStore.getAll().size()).isEqualTo(peerStore.size());
+        // act
+        peerStore.remove(peer.getPeerId());
+        // assert
+        assertThat(peerStore.size()).isEqualTo(0);
+        assertThat(peerStore.getAll().size()).isEqualTo(peerStore.size());
+    }
+
     @Test
     public void overwrite() {
-        peerStore = new PeerStore(new HashMapDbSource());
-
         Peer p1 = Peer.valueOf("ynode://75bff16c@127.0.0.1:32918");
         Peer p2 = Peer.valueOf("ynode://75bff16c@127.0.0.1:32919");
         peerStore.put(p1.getPeerId(), p1);

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/service/pbft/PbftServerStub.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/service/pbft/PbftServerStub.java
@@ -1,6 +1,7 @@
 package io.yggdrash.validator.service.pbft;
 
 import io.grpc.stub.StreamObserver;
+import io.yggdrash.common.config.Constants;
 import io.yggdrash.core.consensus.ConsensusBlock;
 import io.yggdrash.core.consensus.ConsensusBlockChain;
 import io.yggdrash.proto.CommonProto;
@@ -26,8 +27,7 @@ public class PbftServerStub extends PbftServiceGrpc.PbftServiceImplBase {
     }
 
     @Override
-    public void pingPongTime(CommonProto.PingTime request,
-                             StreamObserver<CommonProto.PongTime> responseObserver) {
+    public void pingPongTime(CommonProto.PingTime request, StreamObserver<CommonProto.PongTime> responseObserver) {
         long timestamp = System.currentTimeMillis();
         CommonProto.PongTime pongTime
                 = CommonProto.PongTime.newBuilder().setTimestamp(timestamp).build();
@@ -115,30 +115,41 @@ public class PbftServerStub extends PbftServiceGrpc.PbftServiceImplBase {
     }
 
     @Override
-    public void getPbftBlockList(io.yggdrash.proto.CommonProto.Offset request,
-                                 io.grpc.stub.StreamObserver<PbftProto.PbftBlockList> responseObserver) {
+    public void getPbftBlockList(CommonProto.Offset request, StreamObserver<PbftProto.PbftBlockList> responseObserver) {
         long start = request.getIndex();
+        if (start < 0) {
+            start = 0;
+        }
         long count = request.getCount();
-        long end = Math.min(start - 1 + count, this.blockChain.getBlockChainManager().getLastIndex());
+        long end = Math.min(start - 1 + count, blockChain.getBlockChainManager().getLastIndex());
 
         log.trace("start: {}", start);
         log.trace("end: {}", end);
 
+        responseObserver.onNext(getBlockList(start, end));
+        responseObserver.onCompleted();
+    }
+
+    private PbftProto.PbftBlockList getBlockList(long start, long end) {
         PbftProto.PbftBlockList.Builder builder = PbftProto.PbftBlockList.newBuilder();
-        if (start < end) {
-            for (long l = start; l <= end; l++) {
-                try {
-                    // todo: check efficiency
-                    ConsensusBlock<PbftProto.PbftBlock> block = blockChain.getBlockChainManager().getBlockByIndex(l);
-                    builder.addPbftBlock(block.getInstance());
-                } catch (Exception e) {
-                    break;
+        if (start >= end) {
+            return builder.build();
+        }
+        long bodyLengthSum = 0;
+        for (long l = start; l <= end; l++) {
+            try {
+                // todo: check efficiency
+                ConsensusBlock<PbftProto.PbftBlock> block = blockChain.getBlockChainManager().getBlockByIndex(l);
+                bodyLengthSum += block.getSerializedSize();
+                if (bodyLengthSum > Constants.Limit.BLOCK_SYNC_SIZE) {
+                    return builder.build();
                 }
+                builder.addPbftBlock(block.getInstance());
+            } catch (Exception e) {
+                break;
             }
         }
-
-        responseObserver.onNext(builder.build());
-        responseObserver.onCompleted();
+        return builder.build();
     }
 
     private void updateStatus(PbftStatus status) {

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/store/pbft/PbftBlockKeyStore.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/store/pbft/PbftBlockKeyStore.java
@@ -3,16 +3,15 @@ package io.yggdrash.validator.store.pbft;
 import io.yggdrash.common.config.Constants;
 import io.yggdrash.common.store.datasource.DbSource;
 import io.yggdrash.common.utils.ByteUtil;
-import io.yggdrash.core.exception.NotValidateException;
 import io.yggdrash.core.store.BlockKeyStore;
 import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.spongycastle.util.encoders.Hex;
 
-import java.io.IOException;
 import java.util.concurrent.locks.ReentrantLock;
+
+import static io.yggdrash.common.config.Constants.LEVELDB_SIZE_KEY;
 
 public class PbftBlockKeyStore implements BlockKeyStore<Long, byte[]> {
     private static final Logger log = LoggerFactory.getLogger(PbftBlockKeyStore.class);
@@ -33,13 +32,7 @@ public class PbftBlockKeyStore implements BlockKeyStore<Long, byte[]> {
         options.verifyChecksums(true);
         options.maxOpenFiles(32);
         this.db = dbSource.init(options);
-
-        try {
-            this.size = this.db.getAll().size();
-        } catch (IOException e) {
-            log.debug(e.getMessage());
-            throw new NotValidateException("Store is not valid.");
-        }
+        this.size = loadSize();
     }
 
     @Override
@@ -52,11 +45,9 @@ public class PbftBlockKeyStore implements BlockKeyStore<Long, byte[]> {
         lock.lock();
         try {
             if (!contains(key)) {
-                log.trace("put "
-                        + "(key: " + key + ")"
-                        + "(value : " + Hex.toHexString(value) + ")");
                 db.put(ByteUtil.longToBytes(key), value);
                 size++;
+                db.put(LEVELDB_SIZE_KEY, ByteUtil.longToBytes(size));
             }
         } catch (Exception e) {
             log.debug(e.getMessage());
@@ -74,7 +65,7 @@ public class PbftBlockKeyStore implements BlockKeyStore<Long, byte[]> {
 
         lock.lock();
         try {
-            log.trace("get " + "(" + key + ")");
+            log.trace("get ({})", key);
             return db.get(ByteUtil.longToBytes(key));
         } catch (Exception e) {
             log.debug(e.getMessage());
@@ -112,4 +103,17 @@ public class PbftBlockKeyStore implements BlockKeyStore<Long, byte[]> {
             lock.unlock();
         }
     }
+
+    private long loadSize() {
+        // loading db is just first
+        lock.lock();
+        byte[] sizeByte = db.get(LEVELDB_SIZE_KEY);
+        lock.unlock();
+        if (sizeByte != null) {
+            return ByteUtil.byteArrayToLong(sizeByte);
+        } else {
+            return 0L;
+        }
+    }
+
 }


### PR DESCRIPTION
 * DataSource의 getAll()을 제거하고 Index 별 Key를 보관하여 전체 데이터를 조회하도록 수정하였고, 전체 크기도 db에서 관리되도록 수정하였습니다.
* Pbft,Ebft 서버 Stub에서 getBlockList 최대 응답사이즈 제한(3MB)을 적용하였습니다.