### PR TITLE
Add temporary verification logic to use until the txbody format is fixed

### DIFF
--- a/yggdrash-common/src/main/java/io/yggdrash/common/config/Constants.java
+++ b/yggdrash-common/src/main/java/io/yggdrash/common/config/Constants.java
@@ -13,6 +13,7 @@ public final class Constants {
 
     public static final int BRANCH_LENGTH = 20;
     public static final int BRANCH_HEX_LENGTH = BRANCH_LENGTH * 2;
+    public static final int CONTRACT_VERSION_LENGTH = 20;
 
     public static final String YGGDRASH = "YGGDRASH";
     public static final String BRANCH_ID = "branchId";

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BranchGroup.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BranchGroup.java
@@ -77,7 +77,12 @@ public class BranchGroup {
     }
 
     public Map<String, List<String>> addTransaction(Transaction tx) {
-        String version = tx.getBody().getBody().get("contractVersion").getAsString();
+        // TxBody format has not been fixed yet. The following validation is required until the TxBody is fixed.
+        String version = !tx.getBody().getBody().has("contractVersion")
+                || (!tx.getBody().getBody().get("contractVersion").isJsonPrimitive()
+                || !tx.getBody().getBody().get("contractVersion").getAsJsonPrimitive().isString())
+                ? "" : tx.getBody().getBody().get("contractVersion").getAsString();
+
         int verifyResult = verify(tx.getBranchId(), version);
         if (verifyResult == SystemError.VALID.toValue()) {
             return branches.get(tx.getBranchId()).addTransaction(tx);

--- a/yggdrash-core/src/test/java/io/yggdrash/BlockChainTestUtils.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/BlockChainTestUtils.java
@@ -125,8 +125,7 @@ public class BlockChainTestUtils {
     }
 
     private static Transaction createBranchTx(JsonObject json) {
-
-
+        //TODO stemContract test required
         TransactionBuilder builder = new TransactionBuilder();
         return builder.setTxBody(TestConstants.STEM_CONTRACT, "create", json, false)
                 .setWallet(TestConstants.wallet())

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/TransactionBodyTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/TransactionBodyTest.java
@@ -17,6 +17,8 @@
 package io.yggdrash.core.blockchain;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.yggdrash.common.util.VerifierUtils;
 import io.yggdrash.common.utils.SerializationUtil;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -25,6 +27,8 @@ import org.spongycastle.util.encoders.Hex;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class TransactionBodyTest {
@@ -74,4 +78,61 @@ public class TransactionBodyTest {
         assertEquals(txBody1, txBody4);
     }
 
+    @Test
+    public void transactionBodyFormatValidation() {
+        String txBodyStr = "{\"contractVersion\":\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\",\"method\":\"transfer\","
+                + "\"params\":{\"to\":\"1a0cdead3d1d1dbeef848fef9053b4f0ae06db9e\",\"amount\":1}}";
+        JsonObject txBodyObj = new JsonParser().parse(txBodyStr).getAsJsonObject();
+        TransactionBody txBody = new TransactionBody(txBodyObj);
+        assertTrue(VerifierUtils.verifyTxBodyFormat(txBody));
+
+        String str = "{\"contractVersion\":\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\",\"method\":\"transfer\","
+                + "\"params\":{\"to\":\"1a0cdead3d1d1dbeef848fef9053b4f0ae06db9e\",\"amount\":1},\"hello\":\"hello\","
+                + "\"hi\":\"hi\",\"this\":\"this\",\"is\":\"is\",\"for\":\"for\",\"test\":\"test\"}";
+        txBodyObj = new JsonParser().parse(str).getAsJsonObject();
+        txBody = new TransactionBody(txBodyObj);
+        assertFalse(VerifierUtils.verifyTxBodyFormat(txBody));
+
+        str = "{\"ContractVersion\":\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\",\"method\":\"transfer\","
+                + "\"params\":{\"to\":\"1a0cdead3d1d1dbeef848fef9053b4f0ae06db9e\",\"amount\":1}}";
+        txBodyObj = new JsonParser().parse(str).getAsJsonObject();
+        txBody = new TransactionBody(txBodyObj);
+        assertFalse(VerifierUtils.verifyTxBodyFormat(txBody));
+
+        str = "{\"contractVersion\":\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\",\"Method\":\"transfer\","
+                + "\"params\":{\"to\":\"1a0cdead3d1d1dbeef848fef9053b4f0ae06db9e\",\"amount\":1}}";
+        txBodyObj = new JsonParser().parse(str).getAsJsonObject();
+        txBody = new TransactionBody(txBodyObj);
+        assertFalse(VerifierUtils.verifyTxBodyFormat(txBody));
+
+        str = "{\"contractVersion\":\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\",\"method\":\"transfer\","
+                + "\"Params\":{\"to\":\"1a0cdead3d1d1dbeef848fef9053b4f0ae06db9e\",\"amount\":1}}";
+        txBodyObj = new JsonParser().parse(str).getAsJsonObject();
+        txBody = new TransactionBody(txBodyObj);
+        assertFalse(VerifierUtils.verifyTxBodyFormat(txBody));
+
+        str = "{\"contractVersion\":[\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\","
+                + "\"63589382e2e183e2a6969ebf57bd784dcb29bd43\"],\"method\":[\"1\", \"2\", \"3\"],\"params\":\"abcd\"}";
+        txBodyObj = new JsonParser().parse(str).getAsJsonObject();
+        txBody = new TransactionBody(txBodyObj);
+        assertFalse(VerifierUtils.verifyTxBodyFormat(txBody));
+
+        str = "{\"contractVersion\":\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\",\"method\":[\"1\", \"2\", \"3\"],"
+                + "\"params\":\"abcd\"}";
+        txBodyObj = new JsonParser().parse(str).getAsJsonObject();
+        txBody = new TransactionBody(txBodyObj);
+        assertFalse(VerifierUtils.verifyTxBodyFormat(txBody));
+
+        str = "{\"contractVersion\":\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\",\"method\":\"haha\","
+                + "\"params\":\"abcd\"}";
+        txBodyObj = new JsonParser().parse(str).getAsJsonObject();
+        txBody = new TransactionBody(txBodyObj);
+        assertFalse(VerifierUtils.verifyTxBodyFormat(txBody));
+
+        str = "{\"contractVersion\":\"6a2371e34b780dd39bd56002b1d96c23689cc5dc\",\"method\":\"hello\","
+                + "\"params\":{\"hi\":\"hello\",\"world\":\"!\"}}";
+        txBodyObj = new JsonParser().parse(str).getAsJsonObject();
+        txBody = new TransactionBody(txBodyObj);
+        assertTrue(VerifierUtils.verifyTxBodyFormat(txBody));
+    }
 }

--- a/yggdrash-node/src/main/java/io/yggdrash/node/api/TransactionApiImpl.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/api/TransactionApiImpl.java
@@ -91,7 +91,7 @@ public class TransactionApiImpl implements TransactionApi {
         Map<String, List<String>> errorLogs = branchGroup.addTransaction(transaction);
 
         if (errorLogs.size() > 0) {
-            log.warn("sendTransaction Error : {}", errorLogs);
+            log.warn("SendTransaction Error : {}", errorLogs);
         }
 
         return errorLogs.size() > 0 ? TransactionResponseDto.createBy(tx.txId, false, errorLogs)

--- a/yggdrash-node/src/test/java/io/yggdrash/gateway/controller/TransactionControllerTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/gateway/controller/TransactionControllerTest.java
@@ -90,7 +90,7 @@ public class TransactionControllerTest extends TestConstants.CiTest {
 
         // 트랜잭션 풀에 있는 트랜잭션을 조회 후 블록 내 트랜잭션 조회 로직 추가 필요.
         TransactionDto req =
-                TransactionDto.createBy(BlockChainTestUtils.createBranchTx());
+                TransactionDto.createBy(BlockChainTestUtils.createTransferTx());
 
         MockHttpServletResponse postResponse = mockMvc.perform(post(basePath)
                 .contentType(MediaType.APPLICATION_JSON).content(json.write(req).getJson()))
@@ -98,7 +98,7 @@ public class TransactionControllerTest extends TestConstants.CiTest {
                 .andDo(print())
                 .andReturn().getResponse();
 
-        assertThat(postResponse.getContentAsString()).contains("create");
+        assertThat(postResponse.getContentAsString()).contains("transfer");
         String txId = json.parseObject(postResponse.getContentAsString()).txId;
 
         MockHttpServletResponse getResponse = mockMvc.perform(get(basePath + "/" + txId))


### PR DESCRIPTION
TxBody 형식이 JsonObject 으로 발생할 수 있는 예외가 존재하여,
TxBody가 fix 되기 전까지 사용할  데이터 포맷 검증 로직을 추가하였습니다. 
