### PR TITLE
Add KeepAlive To BsNode

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/core/p2p/KademliaPeerTableGroup.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/p2p/KademliaPeerTableGroup.java
@@ -37,6 +37,11 @@ public class KademliaPeerTableGroup implements PeerTableGroup {
     }
 
     @Override
+    public List<String> getSeedPeerList() {
+        return this.seedPeerList;
+    }
+
+    @Override
     public PeerTable createTable(BranchId branchId) {
         if (tableMap.containsKey(branchId)) {
             return tableMap.get(branchId);

--- a/yggdrash-core/src/main/java/io/yggdrash/core/p2p/PeerTableGroup.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/p2p/PeerTableGroup.java
@@ -25,6 +25,8 @@ public interface PeerTableGroup extends PeerEventListener {
 
     void setSeedPeerList(List<String> seedPeerList);
 
+    List<String> getSeedPeerList();
+
     PeerTable createTable(BranchId branchId);
 
     Set<BranchId> getAllBranchId();

--- a/yggdrash-node/src/main/java/io/yggdrash/node/PeerTask.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/PeerTask.java
@@ -53,6 +53,22 @@ public class PeerTask {
         this.peerDialer = peerDialer;
     }
 
+    @Scheduled(cron = "0 */1 * ? * * ")
+    public void keepAliveToBsNode() {
+        List<String> seedPeers = peerTableGroup.getSeedPeerList();
+        String ownerUri = peerTableGroup.getOwner().getYnodeUri();
+
+        if (seedPeers.contains(ownerUri)) {
+            return;
+        }
+
+        for (BranchId branchId : peerTableGroup.getAllBranchId()) {
+            seedPeers.forEach(seed -> peerDialer.healthCheck(branchId, peerTableGroup.getOwner(), Peer.valueOf(seed)));
+        }
+
+        log.debug("Keep-Alive to BS Node : {} -> {}", ownerUri, seedPeers);
+    }
+
     @Scheduled(fixedRate = 10000)
     public void healthCheck() { // ==> Task of PeerDialer?
         if (!nodeStatus.isUpStatus()) {

--- a/yggdrash-node/src/main/java/io/yggdrash/node/PeerTask.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/PeerTask.java
@@ -23,6 +23,7 @@ import io.yggdrash.core.p2p.Peer;
 import io.yggdrash.core.p2p.PeerDialer;
 import io.yggdrash.core.p2p.PeerTable;
 import io.yggdrash.core.p2p.PeerTableGroup;
+import io.yggdrash.node.config.NodeProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,10 +38,16 @@ public class PeerTask {
     private PeerTableGroup peerTableGroup;
     private PeerDialer peerDialer;
     private NodeStatus nodeStatus;
+    private NodeProperties nodeProperties;
 
     @Autowired
     public void setNodeStatus(NodeStatus nodeStatus) {
         this.nodeStatus = nodeStatus;
+    }
+
+    @Autowired
+    public void setNodeProperties(NodeProperties nodeProperties) {
+        this.nodeProperties = nodeProperties;
     }
 
     @Autowired
@@ -53,14 +60,14 @@ public class PeerTask {
         this.peerDialer = peerDialer;
     }
 
-    @Scheduled(cron = "0 */1 * ? * * ")
+    @Scheduled(cron = "0 */1 * * * * ")
     public void keepAliveToBsNode() {
-        List<String> seedPeers = peerTableGroup.getSeedPeerList();
-        String ownerUri = peerTableGroup.getOwner().getYnodeUri();
-
-        if (seedPeers.contains(ownerUri)) {
+        if (nodeProperties.isSeed()) {
             return;
         }
+
+        List<String> seedPeers = peerTableGroup.getSeedPeerList();
+        String ownerUri = peerTableGroup.getOwner().getYnodeUri();
 
         for (BranchId branchId : peerTableGroup.getAllBranchId()) {
             seedPeers.forEach(seed -> peerDialer.healthCheck(branchId, peerTableGroup.getOwner(), Peer.valueOf(seed)));


### PR DESCRIPTION
Bootstrap Node 의 db 삭제 후 재실행 시 이전 peer 목록과 연결이 안되는 이슈를 해결하기 위하여 PeerTask 에 1분마다 BS 노드로 KeepAlive(=HealthCheck) 를 하도록 추가하였습니다. 