### PR TITLE
Compare receivedIndex and lastIndex

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/core/net/BlockServiceConsumer.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/net/BlockServiceConsumer.java
@@ -63,25 +63,22 @@ public class BlockServiceConsumer<T> implements BlockConsumer<T> {
     public void broadcastBlock(ConsensusBlock<T> block) {
         try {
             BranchId branchId = block.getBranchId();
-            long lastIndex = branchGroup.getLastIndex(branchId);
+            long nextIndex = branchGroup.getLastIndex(branchId) + 1;
             long receivedIndex = block.getIndex();
 
-            if (receivedIndex == lastIndex) {
+            if (receivedIndex < nextIndex) {
                 return;
-            }
-
-            long nextIndex = lastIndex + 1;
-            if (nextIndex < receivedIndex) {
+            } else if (receivedIndex == nextIndex) {
+                branchGroup.addBlock(block, true);
+            } else {
                 // Catchup Event!
                 if (listener != null) {
                     log.info("CatchUp required. received={} expected={}", receivedIndex, nextIndex);
                     listener.catchUpRequest(block);
                 }
-            } else {
-                branchGroup.addBlock(block, true);
             }
         } catch (Exception e) {
-            log.warn("BroadcastBlock ERR={}", e.getMessage());
+            log.debug("BroadcastBlock ERR={}", e.getMessage());
         }
     }
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/net/BlockServiceConsumer.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/net/BlockServiceConsumer.java
@@ -62,9 +62,15 @@ public class BlockServiceConsumer<T> implements BlockConsumer<T> {
     @Override
     public void broadcastBlock(ConsensusBlock<T> block) {
         try {
-            long nextIndex = branchGroup.getLastIndex(block.getBranchId()) + 1;
+            BranchId branchId = block.getBranchId();
+            long lastIndex = branchGroup.getLastIndex(branchId);
             long receivedIndex = block.getIndex();
 
+            if (receivedIndex == lastIndex) {
+                return;
+            }
+
+            long nextIndex = lastIndex + 1;
             if (nextIndex < receivedIndex) {
                 // Catchup Event!
                 if (listener != null) {

--- a/yggdrash-core/src/main/java/io/yggdrash/core/p2p/AbstractBlockChainHandler.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/p2p/AbstractBlockChainHandler.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractBlockChainHandler<T> extends DiscoveryHandler<T> {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractBlockChainHandler.class);
-    protected static final int DEFAULT_LIMIT = 10;
+    protected static final int DEFAULT_LIMIT = 100;
 
     private final TransactionServiceGrpc.TransactionServiceStub transactionAsyncStub;
     private final StreamObserver<CommonProto.Empty> emptyResponseStreamObserver;

--- a/yggdrash-core/src/test/java/io/yggdrash/core/net/BlockServiceConsumerTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/net/BlockServiceConsumerTest.java
@@ -75,7 +75,9 @@ public class BlockServiceConsumerTest {
     public void broadcastBlock() {
         assertEquals(0, branchGroup.getBranch(branchId).getBlockChainManager().getLastIndex());
 
-        blockServiceConsumer.broadcastBlock(BlockChainTestUtils.createNextBlock());
+        ConsensusBlock<PbftProto.PbftBlock> nextBlock = BlockChainTestUtils.createNextBlock();
+        blockServiceConsumer.broadcastBlock(nextBlock);
+        blockServiceConsumer.broadcastBlock(nextBlock);
 
         assertEquals(1, branchGroup.getBranch(branchId).getBlockChainManager().getLastIndex());
     }


### PR DESCRIPTION
블록 중복 수신 시 receivedIndex 와 blockChain 의 lastIndex 가 같은 경우 return 하여 불필요한 verify 를 중복으로 진행하지 않도록 하였습니다.

블록을 전파하는 쪽에서 브로드캐스트 하려는 노드의 bestBlock 의 높이를 확인 후 브로드캐스트 하는 방법은, 상태를 관리 작업 및 테스트등 들이 필요하여 다음과 같이 수신하는 쪽에서 체크하도록 하였습니다. 

더 효율적인 방법을 고려하여 추후 작업하도록 하겠습니다. 