### PR TITLE
Add catchUpRequest listener and test it in integrationTest

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainSyncManager.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainSyncManager.java
@@ -205,6 +205,7 @@ public class BlockChainSyncManager implements SyncManager {
 
         long bestBlock = from.getBestBlock();
         long curBestBlock = blockChain.getBlockChainManager().getLastIndex();
+        log.trace("catchUpRequest(): bestBlock from peer=({}), curBestBlock of branch=({})", bestBlock, curBestBlock);
 
         if (curBestBlock >= bestBlock) {
             return;

--- a/yggdrash-core/src/main/java/io/yggdrash/core/net/DiscoveryServiceConsumer.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/net/DiscoveryServiceConsumer.java
@@ -50,7 +50,6 @@ public class DiscoveryServiceConsumer implements DiscoveryConsumer {
         if ("Ping".equals(msg) && peerTableGroup.getOwner().toAddress().equals(to.toAddress())) {
             peerTableGroup.addPeer(branchId, from);
 
-            //TODO Test!
             if (listener != null) {
                 listener.catchUpRequest(branchId, from);
             }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/p2p/DiscoveryHandler.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/p2p/DiscoveryHandler.java
@@ -85,6 +85,7 @@ public class DiscoveryHandler<T> implements BlockChainHandler<T> {
                 .setFrom(owner.getYnodeUri())
                 .setTo(peer.getYnodeUri())
                 .setBranch(ByteString.copyFrom(branchId.getBytes()))
+                .setBestBlock(owner.getBestBlock())
                 .build();
         return peerBlockingStub.ping(request).getPong();
     }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/store/BranchStore.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/store/BranchStore.java
@@ -197,9 +197,6 @@ public class BranchStore implements ReadWriterStore<String, JsonObject>, BranchS
         JsonObject jsonValidatorSet = get(PrefixKeyEnum.VALIDATORS.toValue());
         if (jsonValidatorSet != null) {
             validatorSet = JsonUtil.generateJsonToClass(jsonValidatorSet.toString(), ValidatorSet.class);
-        } else {
-            validatorSet = new ValidatorSet();
-            log.warn("Could not get ValidatorSet from branchStore. ValidatorSet=null");
         }
         return validatorSet;
     }

--- a/yggdrash-core/src/main/resources/branch-yggdrash-open-testnet.json
+++ b/yggdrash-core/src/main/resources/branch-yggdrash-open-testnet.json
@@ -1,0 +1,88 @@
+{
+  "name": "YGGDRASH",
+  "symbol": "YGGDRASH",
+  "property": "platform",
+  "description": "YGGDRASH TESTNET, TRUST-based Multi-dimensional Blockchain",
+  "contracts": [
+    {
+      "contractVersion": "178b44b22d8c6d5bb08175fa2fcab15122ca8d1e",
+      "init": {},
+      "description": "The Basis of the YGGDRASH Ecosystem. It is also an aggregate and a blockchain containing information of all Branch Chains.",
+      "name": "STEM",
+      "isSystem": true
+    },
+    {
+      "contractVersion": "19b9710dc8f0442d09a1b5e632f7200afe751d60",
+      "isSystem": true,
+      "init": {
+        "alloc": {
+          "101167aaf090581b91c08480f6e559acdd9a3ddd": {
+            "balance": "1000000000000000000000"
+          },
+          "ffcbff030ecfa17628abdd0ff1990be003da35a2": {
+            "balance": "1000000000000000000000"
+          },
+          "b0aee21c81bf6057efa9a321916f0f1a12f5c547": {
+            "balance": "1000000000000000000000"
+          },
+          "1a0cdead3d1d1dbeef848fef9053b4f0ae06db9e": {
+            "balance": "1000000000000000000000"
+          },
+          "57c6510966903044581c148bb67eb47dbbeebef1": {
+            "balance": "1000000000000000000000"
+          },
+          "d2a5721e80dc439385f3abc5aab0ac4ed2b1cd95": {
+            "balance": "1000000000000000000000"
+          },
+          "cee3d4755e47055b530deeba062c5bd0c17eb00f": {
+            "balance": "994000000000000000000000"
+          },
+          "4e5cbe1d0db35add81e7f2840eeb250b5b469161": {
+            "balance": "994000000000000000000000"
+          },
+          "415e01c639d83a13308264691330d4e9b68f1012": {
+            "balance": "1000000000000000000000"
+          },
+          "624d4ec36a83992d451b39ac9dd5b9cd36cde630": {
+            "balance": "1000000000000000000000"
+          },
+          "d8502005cd4154d8600fb6de4e1b84391b18c2d0": {
+            "balance": "1000000000000000000000"
+          },
+          "06afa0fdf4299e19e4bc084c1db7cbbfb5717272": {
+            "balance": "1000000000000000000000"
+          },
+          "be39c9238430846fe6bd94d883917d6c4f4d9620": {
+            "balance": "1000000000000000000000"
+          },
+          "8236e5ebc70a7fa47436b60b836454c1b2e4b88f": {
+            "balance": "1000000000000000000000"
+          }
+        }
+      },
+      "description": "YEED is the currency used inside YGGDRASH. The vitality of the new branch chain is decided by the amount of YEED, which will be consumed gradually.",
+      "name": "YEED"
+    },
+    {
+      "contractVersion": "30783a1311b9c68dd3a92596d650ae6914b01658",
+      "isSystem": true,
+      "init": {
+        "validators": [
+          "5e96dcb9bf4b2288ba74fa2c785b07b6366c0687",
+          "20a58d12133a5a4a6a4126fb2c77cda26d765fee",
+          "59df14ab7c54430b5e7474a8b02a5d37984031bf",
+          "1705f3e59375a142976308bc3c0c620ddd6db105",
+          "f2ce42aa0afd83ee2791789b1fe4dfbebde21344"
+        ]
+      },
+      "name": "DPoA",
+      "description": "This contract is for a validator."
+    }
+  ],
+  "timestamp": "000001674dc56231",
+  "consensus": {
+    "algorithm": "pbft",
+    "period": "* * * * * *"
+  },
+  "governanceContract": "DPoA"
+}

--- a/yggdrash-core/src/main/resources/branch-yggdrash.json
+++ b/yggdrash-core/src/main/resources/branch-yggdrash.json
@@ -2,7 +2,7 @@
   "name": "YGGDRASH",
   "symbol": "YGGDRASH",
   "property": "platform",
-  "description": "YGGDRASH TESTNET, TRUST-based Multi-dimensional Blockchain",
+  "description": "TRUST-based Multi-dimensional Blockchains",
   "contracts": [
     {
       "contractVersion": "178b44b22d8c6d5bb08175fa2fcab15122ca8d1e",
@@ -39,24 +39,6 @@
           },
           "4e5cbe1d0db35add81e7f2840eeb250b5b469161": {
             "balance": "994000000000000000000000"
-          },
-          "415e01c639d83a13308264691330d4e9b68f1012": {
-            "balance": "1000000000000000000000"
-          },
-          "624d4ec36a83992d451b39ac9dd5b9cd36cde630": {
-            "balance": "1000000000000000000000"
-          },
-          "d8502005cd4154d8600fb6de4e1b84391b18c2d0": {
-            "balance": "1000000000000000000000"
-          },
-          "06afa0fdf4299e19e4bc084c1db7cbbfb5717272": {
-            "balance": "1000000000000000000000"
-          },
-          "be39c9238430846fe6bd94d883917d6c4f4d9620": {
-            "balance": "1000000000000000000000"
-          },
-          "8236e5ebc70a7fa47436b60b836454c1b2e4b88f": {
-            "balance": "1000000000000000000000"
           }
         }
       },
@@ -68,11 +50,31 @@
       "isSystem": true,
       "init": {
         "validators": [
-          "5e96dcb9bf4b2288ba74fa2c785b07b6366c0687",
-          "20a58d12133a5a4a6a4126fb2c77cda26d765fee",
-          "59df14ab7c54430b5e7474a8b02a5d37984031bf",
-          "1705f3e59375a142976308bc3c0c620ddd6db105",
-          "f2ce42aa0afd83ee2791789b1fe4dfbebde21344"
+          "101167aaf090581b91c08480f6e559acdd9a3ddd",
+          "ffcbff030ecfa17628abdd0ff1990be003da35a2",
+          "b0aee21c81bf6057efa9a321916f0f1a12f5c547",
+          "4e5cbe1d0db35add81e7f2840eeb250b5b469161",
+          "77283a04b3410fe21ba5ed04c7bd3ba89e70b78c",
+          "9911fb4663637706811a53a0e0b4bcedeee38686",
+          "2ee2eb80c93d031147c21ba8e2e0f0f4a33f5312",
+          "51e2128e8deb622c2ec6dc38f9d895f0be044eb4",
+          "047269a50640ed2b0d45d461488c13abad1e0fac",
+          "21640f2116389a3e37462fd6b68b969e490b6a50",
+          "63fef4912dc8b0781351b18eb9be450638ea2c17",
+          "34e3b1fb13c865fd558e7aa1081377bb5dca43cb",
+          "75fad0fa463b34e659d2bb3b9324b32faed67863",
+          "af79407d6c55c950c09ba4a30f8eae55f05508a2",
+          "f871740aedb55e0d4f110502d5221c4a648f4c27",
+          "f0a714707c286ba16e32fe18e90c9e13922edf5d",
+          "d6f2eae80c8dfedc279111b4ebf2298de9d62b02",
+          "f18db7b37206c58eb7ff8b6a0bc903f76dfcd0d8",
+          "ff50d378b0d6f642826efd475508f372aa2e858a",
+          "ab5506912430d4fc539f21afb0f47d2244cdfa76",
+          "70507099ee03b3e67b5b343d483e0e835018db4b",
+          "e58d0858512a047b2debbcfeab318bb5eeec7dee",
+          "5519a46223c025707a12dda2d3fffe9634b274c0",
+          "8a99217f44c65287a9cc12523b80c3e57782afb1",
+          "fc534627231364101088709fdf030d99f1c52d38"
         ]
       },
       "name": "DPoA",

--- a/yggdrash-core/src/test/java/io/yggdrash/PeerTestUtils.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/PeerTestUtils.java
@@ -27,11 +27,12 @@ import io.yggdrash.core.p2p.PeerTableGroupBuilder;
 import io.yggdrash.core.store.StoreBuilder;
 
 import java.util.Collections;
+import java.util.List;
 
 public class PeerTestUtils {
     public static final int SEED_PORT = 32918;
     public static final int OWNER_PORT = 32920;
-    private static final String NODE_URI_PREFIX = "ynode://75bff16c@127.0.0.1:";
+    public static final String NODE_URI_PREFIX = "ynode://75bff16c@127.0.0.1:";
     private static final StoreBuilder storeBuilder = StoreBuilder.newBuilder().setConfig(new DefaultConfig());
 
     private PeerTestUtils() {}
@@ -41,12 +42,16 @@ public class PeerTestUtils {
     }
 
     public static PeerTableGroup createTableGroup(int port, PeerDialer peerDialer) {
+        return createTableGroup(port, peerDialer, Collections.singletonList(NODE_URI_PREFIX + SEED_PORT));
+    }
+
+    public static PeerTableGroup createTableGroup(int port, PeerDialer peerDialer, List<String> seedPeerList) {
         Peer owner = Peer.valueOf(NODE_URI_PREFIX + port);
         return PeerTableGroupBuilder.newBuilder()
                 .setOwner(owner)
                 .setStoreBuilder(storeBuilder)
                 .setPeerDialer(peerDialer)
-                .setSeedPeerList(Collections.singletonList(NODE_URI_PREFIX + SEED_PORT))
+                .setSeedPeerList(seedPeerList)
                 .build();
     }
 

--- a/yggdrash-node/src/main/java/io/yggdrash/node/service/BlockServiceFactory.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/service/BlockServiceFactory.java
@@ -91,7 +91,7 @@ public class BlockServiceFactory {
         public void broadcastPbftBlock(PbftProto.PbftBlock request,
                                        StreamObserver<CommonProto.Empty> responseObserver) {
             PbftBlock block = new PbftBlock(request);
-            log.info("Received block: id=[{}], hash={}", block.getIndex(), block.getHash());
+            log.debug("Received block: id=[{}], hash={}", block.getIndex(), block.getHash());
             blockConsumer.broadcastBlock(block);
             responseObserver.onNext(EMPTY);
             responseObserver.onCompleted();

--- a/yggdrash-node/src/main/java/io/yggdrash/node/service/BlockServiceFactory.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/service/BlockServiceFactory.java
@@ -91,7 +91,7 @@ public class BlockServiceFactory {
         public void broadcastPbftBlock(PbftProto.PbftBlock request,
                                        StreamObserver<CommonProto.Empty> responseObserver) {
             PbftBlock block = new PbftBlock(request);
-            log.debug("Received block: id=[{}], hash={}", block.getIndex(), block.getHash());
+            log.info("Received block: id=[{}], hash={}", block.getIndex(), block.getHash());
             blockConsumer.broadcastBlock(block);
             responseObserver.onNext(EMPTY);
             responseObserver.onCompleted();

--- a/yggdrash-node/src/main/java/io/yggdrash/node/service/DiscoveryService.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/service/DiscoveryService.java
@@ -2,6 +2,7 @@ package io.yggdrash.node.service;
 
 import io.grpc.stub.StreamObserver;
 import io.yggdrash.core.blockchain.BranchId;
+import io.yggdrash.core.blockchain.SyncManager;
 import io.yggdrash.core.net.DiscoveryConsumer;
 import io.yggdrash.core.p2p.Peer;
 import io.yggdrash.node.springboot.grpc.GrpcService;
@@ -16,9 +17,17 @@ public class DiscoveryService extends DiscoveryServiceGrpc.DiscoveryServiceImplB
 
     private final DiscoveryConsumer discoveryConsumer;
 
+    private SyncManager syncManager;
+
     @Autowired
     public DiscoveryService(DiscoveryConsumer discoveryConsumer) {
         this.discoveryConsumer = discoveryConsumer;
+    }
+
+    @Autowired
+    private void setSyncManager(SyncManager syncManager) {
+        this.syncManager = syncManager;
+        discoveryConsumer.setListener(syncManager);
     }
 
     @Override

--- a/yggdrash-node/src/test/java/io/yggdrash/node/AbstractNodeTesting.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/AbstractNodeTesting.java
@@ -61,8 +61,31 @@ public class AbstractNodeTesting {
         this.factory = mockFactory();
     }
 
+    private void setFactory() {
+        if (factory == null) {
+            setUp();
+        }
+    }
+
     protected TestNode createAndStartNode(int port, boolean enableBranch) {
-        TestNode node = new TestNode(factory, port, enableBranch);
+        setFactory();
+        return createAndStartNode(new TestNode(factory, port, enableBranch));
+    }
+
+    protected TestNode createAndStartNode(int port, boolean enableBranch, List<String> seedPeerList) {
+        setFactory();
+        TestNode nodeWithSeedPeers = new TestNode(factory, port, enableBranch, seedPeerList);
+        return createAndStartNode(nodeWithSeedPeers);
+    }
+
+    protected TestNode createAndStartNode(
+            int port, boolean enableBranch, List<String> seedPeerList, List<String> validatorList) {
+        setFactory();
+        TestNode proxyNode = new TestNode(factory, port, enableBranch, seedPeerList, validatorList);
+        return createAndStartNode(proxyNode);
+    }
+
+    private TestNode createAndStartNode(TestNode node) {
         nodeList.add(node);
         createAndStartServer(node);
         grpcCleanup.register(node.server);
@@ -86,6 +109,7 @@ public class AbstractNodeTesting {
     }
 
     void addService(TestNode node, ServerBuilder builder) {
+        node.discoveryConsumer.setListener(node.getSyncManger());
         builder.addService(new DiscoveryService(node.discoveryConsumer));
         if (node.transactionService != null) {
             builder.addService(node.transactionService);

--- a/yggdrash-node/src/test/java/io/yggdrash/node/IntegrationTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/IntegrationTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2019 Akashic Foundation
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package io.yggdrash.node;
+
+import io.yggdrash.BlockChainTestUtils;
+import io.yggdrash.PeerTestUtils;
+import io.yggdrash.common.contract.ContractVersion;
+import io.yggdrash.core.blockchain.BlockChain;
+import io.yggdrash.core.blockchain.BlockChainManager;
+import io.yggdrash.core.blockchain.BranchId;
+import io.yggdrash.core.consensus.ConsensusBlock;
+import io.yggdrash.core.p2p.BlockChainDialer;
+import io.yggdrash.core.p2p.BlockChainHandlerFactory;
+import io.yggdrash.core.p2p.DiscoveryHandler;
+import io.yggdrash.core.p2p.Peer;
+import io.yggdrash.core.p2p.PeerDialer;
+import io.yggdrash.node.service.PeerHandlerProvider;
+import io.yggdrash.proto.PbftProto;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class IntegrationTest extends TcpNodeTesting {
+
+    private static final Scanner scan = new Scanner(System.in);
+
+    private static final Integer BOOTSTRAP = 0;
+    private static final Integer PROXY = 1;
+    private static final Integer GENERAL = 2;
+    private static final Integer VALIDATOR1 = 3;
+    private static final Integer VALIDATOR2 = 4;
+    private static final Integer VALIDATOR3 = 5;
+    private static final Integer VALIDATOR4 = 6;
+    private static final Integer VALIDATOR5 = 7;
+
+    private static Integer DEFAULT_PORT_NUM = 33333;
+
+    //TODO These Uris/ BranchId/ ContractVersion should be settable
+    private static String bootStrapNodeUri = "ynode://00@127.0.0.1:32918";
+    private static String proxyNodeUri = "ynode://f871740aedb55e0d4f110502d5221c4a648f4c27@127.0.0.1:32911";
+    private static String generalNodeUri = "ynode://d5acd6a61102604b1ca4fbd88c17b631e0de3877@127.0.0.1:32919";
+    private static String validatorNode1Uri = "ynode://77283a04b3410fe21ba5ed04c7bd3ba89e70b78c@127.0.0.1:32901";
+    private static String validatorNode2Uri = "ynode://9911fb4663637706811a53a0e0b4bcedeee38686@127.0.0.1:32902";
+    private static String validatorNode3Uri = "ynode://2ee2eb80c93d031147c21ba8e2e0f0f4a33f5312@127.0.0.1:32903";
+    private static String validatorNode4Uri = "ynode://51e2128e8deb622c2ec6dc38f9d895f0be044eb4@127.0.0.1:32904";
+    private static String validatorNode5Uri = "ynode://047269a50640ed2b0d45d461488c13abad1e0fac@127.0.0.1:32905";
+
+    private static BranchId branchId = BranchId.of("3b898581ef0a6f172d31740c9de024101f1293a6");
+    private static ContractVersion yeedContract = ContractVersion.of("30783a1311b9c68dd3a92596d650ae6914b01658");
+
+    //private static TestNode proxyTestNode;
+
+    private static List<Peer> peers;
+    private static List<DiscoveryHandler> peerDiscoveryHandlers;
+    private static List<PeerHandlerProvider.PbftPeerHandler> peerPbftHandlers;
+
+    public IntegrationTest() {
+        init();
+    }
+
+    // Create a peer cluster for generating and broadcasting blocks
+    private List<Peer> createPeers() {
+        Peer bootstrapNode = Peer.valueOf(bootStrapNodeUri);
+        Peer proxyNode = Peer.valueOf(proxyNodeUri);
+        Peer generalNode = Peer.valueOf(generalNodeUri);
+        Peer validatorNode1 = Peer.valueOf(validatorNode1Uri);
+        Peer validatorNode2 = Peer.valueOf(validatorNode2Uri);
+        Peer validatorNode3 = Peer.valueOf(validatorNode3Uri);
+        Peer validatorNode4 = Peer.valueOf(validatorNode4Uri);
+        Peer validatorNode5 = Peer.valueOf(validatorNode5Uri);
+
+        List<Peer> peerCluster = new ArrayList<>();
+        peerCluster.add(bootstrapNode);
+        peerCluster.add(proxyNode);
+        peerCluster.add(generalNode);
+        peerCluster.add(validatorNode1);
+        peerCluster.add(validatorNode2);
+        peerCluster.add(validatorNode3);
+        peerCluster.add(validatorNode4);
+        peerCluster.add(validatorNode5);
+        peers = peerCluster;
+
+        return peerCluster;
+    }
+
+    // Create peerHandler cluster to send rpc msg (findPeers, ping)
+    private List<PeerHandlerProvider.PbftPeerHandler> createPbftHandlers() {
+        return createPeers().stream()
+                .map(p -> new PeerHandlerProvider.PbftPeerHandler(createChannel(p), p)).collect(Collectors.toList());
+    }
+
+    // Create peerHandler cluster to send rpc msg (syncBlock, syncTx, broadcastBlock, broadcastTx)
+    private List<DiscoveryHandler> createDiscoveryHandlers() {
+        return peers.stream()
+                .map((Function<Peer, DiscoveryHandler>) DiscoveryHandler::new)
+                .collect(Collectors.toList());
+    }
+
+    // TODO doesn't work (ERR:Call Interrupted Exception)
+    private TestNode createProxyTestNode() {
+        //BlockChainHandlerFactory factory = PeerHandlerProvider.factory();
+        //return TestNode.createProxyNode(factory, Collections.singletonList(bootStrapNodeUri), getValidatorUris());
+        return createAndStartNode(
+                32920, true, Collections.singletonList(bootStrapNodeUri), getValidatorUris());
+    }
+
+    private List<String> getValidatorUris() {
+        List<String> validators = new ArrayList<>();
+        validators.add(validatorNode1Uri);
+        validators.add(validatorNode2Uri);
+        validators.add(validatorNode3Uri);
+        validators.add(validatorNode4Uri);
+        validators.add(validatorNode5Uri);
+        return validators;
+    }
+
+    private List<TestNode> createTestNodes(int nodeCnt, boolean enableBranch) {
+        return createTestNodes(nodeCnt, enableBranch, Collections.singletonList(bootStrapNodeUri));
+    }
+
+    private List<TestNode> createTestNodes(int nodeCnt, boolean enableBranch, List<String> seedPeerList) {
+        return IntStream.range(DEFAULT_PORT_NUM, DEFAULT_PORT_NUM + nodeCnt)
+                .mapToObj(i -> createAndStartNode(i, enableBranch, seedPeerList))
+                .collect(Collectors.toList());
+    }
+
+    private void init() {
+        peerPbftHandlers = createPbftHandlers();
+        peerDiscoveryHandlers = createDiscoveryHandlers();
+        //proxyTestNode = createProxyTestNode();
+    }
+
+    /* Test */
+
+    //@Test
+    public void shouldNotNull() {
+        Assert.assertNotNull(peers);
+        Assert.assertNotNull(peerDiscoveryHandlers);
+        Assert.assertEquals(peers.size(), peerDiscoveryHandlers.size());
+        //Assert.assertNotNull(proxyTestNode);
+    }
+
+    //@Test
+    public void creatTestNodesTest() {
+        List<TestNode> nodes = createTestNodes(2, true);
+        Assert.assertNotNull(nodes);
+        Assert.assertEquals(2, nodes.size());
+
+        nodes.forEach(TestNode::bootstrapping);
+        Integer port = DEFAULT_PORT_NUM;
+        for (TestNode n : nodes) {
+            isInitializedProperly(n);
+            Assert.assertEquals(0, n.getActivePeerCount()); // no validator peerHandlers
+
+            String testNodeUri = PeerTestUtils.NODE_URI_PREFIX + port;
+            Assert.assertEquals(testNodeUri, n.peerTableGroup.getOwner().getYnodeUri());
+            port++;
+        }
+    }
+
+    /*
+    @Test
+    public void proxyNodeTest() {
+        isInitializedProperly(proxyTestNode);
+        Assert.assertEquals(5, proxyTestNode.getActivePeerCount()); // validator peerHandlers count
+
+        String proxyTestNodeUri = PeerTestUtils.NODE_URI_PREFIX + PeerTestUtils.OWNER_PORT;
+        Assert.assertEquals(proxyTestNodeUri, proxyTestNode.peerTableGroup.getOwner().getYnodeUri());
+    }
+    */
+
+    private void isInitializedProperly(TestNode n) {
+        Assert.assertFalse(n.isSeed());
+        Assert.assertTrue(n.peerTableGroup.getSeedPeerList().contains(bootStrapNodeUri));
+
+        BlockChain branch = n.getBranchGroup().getBranch(branchId);
+        Assert.assertNotNull(branch);
+        Assert.assertTrue(branch.containBranchContract(yeedContract));
+
+        BlockChainManager blockChainManager = branch.getBlockChainManager();
+        if (blockChainManager.getLastIndex() == 0) { // not synced yet
+            Assert.assertEquals(3, blockChainManager.countOfTxs()); // genesis txs
+            Assert.assertEquals(1, blockChainManager.countOfBlocks()); // only genesis block
+        }
+    }
+
+    /* Getter */
+
+    private PeerDialer createPeerDialer() {
+        BlockChainHandlerFactory factory = PeerHandlerProvider.factory();
+        PeerDialer peerDialer = new BlockChainDialer(factory);
+        peerDialer.addConsensus(branchId, "pbft");
+        return peerDialer;
+    }
+
+    private List<Peer> getPeers() {
+        return peers;
+    }
+
+    private List<PeerHandlerProvider.PbftPeerHandler> getPbftPeerHandlers() {
+        return peerPbftHandlers;
+    }
+
+    private List<DiscoveryHandler> getDiscoveryHandlers() {
+        return peerDiscoveryHandlers;
+    }
+
+    /* Main Test */
+
+    private static IntegrationTest test;
+
+    public static void main(String[] args) throws Exception {
+        test = new IntegrationTest();
+        // print basic node config info
+        test.getPeers().stream().map(Peer::getYnodeUri).forEach(System.out::println);
+
+        // TODO query whether to overwrite node configuration
+
+        run();
+    }
+
+    private static void run() throws Exception {
+        System.out.println("[1] CatchUpRequest Test");
+        switch (scan.nextLine()) {
+            case "1":
+                String catchUpTestDescription = "CatchUpRequest 는 syncBlock, ping, broadcastBlock 시 발생합니다. "
+                        + "즉, 요청한 블록의 높이가 더 높을 경우, healthCheck 시 peer 의 bestBlock 이 더 높은 경우, "
+                        + "브로드캐스트 받은 블록의 높이가 더 높은 경우에 발생해야 합니다. "
+                        + "CatchUpRequest Test 는 3가지 상황에서 모두 요청이 발생하는지 확인하기 위함입니다.";
+                System.out.println(catchUpTestDescription);
+                validateCatchupRequest();
+                break;
+            default:
+                break;
+        }
+    }
+
+    /* Methods for TestNodes and Handlers */
+
+    private static void broadcastTxs(PeerHandlerProvider.PbftPeerHandler t, int cnt) {
+        IntStream.range(0, cnt)
+                .mapToObj(i -> BlockChainTestUtils.createTransferTx(branchId, yeedContract))
+                .collect(Collectors.toList())
+                .forEach(t::broadcastTx);
+    }
+
+    private static void broadcastBlocks(PeerHandlerProvider.PbftPeerHandler t, int cnt, int txSize) {
+        BlockChainTestUtils.createBlockListFilledWithTx(cnt, txSize).forEach(t::broadcastBlock);
+    }
+
+    private static void broadcastBlock(PeerHandlerProvider.PbftPeerHandler t,
+                                       ConsensusBlock<PbftProto.PbftBlock> block) {
+        t.broadcastBlock(block);
+    }
+
+    private static void findPeers(TestNode n, Peer to, Peer target) {
+        addPeer(n, to);
+        List<Peer> res = new ArrayList<>();
+        n.getPeerNetwork()
+                .getHandlerList(branchId)
+                .stream()
+                .map(blockChainHandler -> blockChainHandler.findPeers(branchId, target))
+                .forEach(res::addAll);
+        //from.peerTableGroup.getPeerTable(branchId).dropPeer(to);
+    }
+
+    private static void findPeers(DiscoveryHandler t, Peer target) {
+        t.findPeers(branchId, target);
+    }
+
+    private static void addPeer(TestNode n, Peer p) {
+        n.peerTableGroup.addPeer(branchId, p);
+    }
+
+    public static void addPeer(TestNode n, List<Peer> peerList) {
+        peerList.forEach(p -> addPeer(n, p));
+    }
+
+    private static void ping(TestNode n, Peer t) {
+        n.peerTask.healthCheck();
+    }
+
+    private static void ping(DiscoveryHandler targetHandler, Peer from) {
+        targetHandler.ping(branchId, from, "Ping");
+        //createPeerDialer().healthCheck(
+        //        BranchId.of("a1d0ade6dcb5db356c2e8a5ee09d2568072eef09"), from, handler.getPeer());
+    }
+
+    private static void pingWithBlockHeight(TestNode n, DiscoveryHandler t, long blockHeight) {
+        if (blockHeight > 0) {
+            n.getPeer().setBestBlock(blockHeight);
+        }
+        ping(n, t.getPeer());
+    }
+
+    private static void syncBlock(TestNode n, PeerHandlerProvider.PbftPeerHandler targetHandler) {
+        n.getSyncManger().syncBlock(targetHandler, n.getBranchGroup().getBranch(branchId));
+    }
+
+    private static void syncBlock(PeerHandlerProvider.PbftPeerHandler targetHandler, long offset) {
+        targetHandler.syncBlock(branchId, offset);
+    }
+
+    private static void syncBlock(TestNode n, PeerHandlerProvider.PbftPeerHandler target, int cnt) {
+        IntStream.range(0, cnt).forEach(i -> syncBlock(n, target));
+    }
+
+    private static void syncTx(TestNode n, PeerHandlerProvider.PbftPeerHandler targetHandler) {
+        n.getSyncManger().syncTransaction(targetHandler, n.getBranchGroup().getBranch(branchId));
+    }
+
+    private static void syncTx(PeerHandlerProvider.PbftPeerHandler targetHandler) {
+        targetHandler.syncTx(branchId);
+    }
+
+    private static void shutdown(TestNode n) {
+        n.shutdown();
+    }
+
+    private void stopHandler(DiscoveryHandler targetHandler) {
+        targetHandler.stop();
+    }
+
+    /* Test Scenarios (something bad requests or process validation) */
+
+    private static void validateCatchupRequest() {
+        TestNode node = test.createTestNodes(1, true).get(0);
+        test.isInitializedProperly(node);
+        node.bootstrapping();
+
+        // Make sure that catchupRequest works well (when syncBlock, ping, broadcastBlock)
+        addPeer(node, test.getPeers().get(PROXY));
+        //Set blockHeight higher than the targets' will result in a catchup request.
+        pingWithBlockHeight(node, test.getDiscoveryHandlers().get(PROXY), 700);
+        //If the height of the transferred block is higher than the target's bestBlock will result in a catchup request.
+        broadcastBlocks(test.getPbftPeerHandlers().get(PROXY), 700, 0);
+        //If the height of the requested block is higher than the target's bestBlock will result in a catchup request.
+        syncBlock(node, test.getPbftPeerHandlers().get(PROXY), 700);
+    }
+
+    private static void tooMuchFindPeersRequest(TestNode n, Peer to, Peer target, int cnt) {
+        IntStream.range(0, cnt).forEach(i -> findPeers(n, to, target));
+        /*
+        //Example
+        TestNode proxyTestNode = test.getProxyTestNode();
+        proxyTestNode.bootstrapping();
+        ping(test.getDiscoveryHandlers().get(PROXY), node.getPeer());
+        broadcastTxs(test.getPbftPeerHandlers().get(PROXY), 2);
+        findPeers(node, test.getPeers().get(PROXY), test.getPeers().get(GENERAL));
+        findPeers(test.getDiscoveryHandlers().get(GENERAL), node.getPeer());
+        findPeers(test.getDiscoveryHandlers().get(PROXY), node.getPeer());
+        syncBlock(node, test.getPbftPeerHandlers().get(PROXY));
+        syncBlock(test.getPbftPeerHandlers().get(PROXY), 30);
+        syncTx(node, test.getPbftPeerHandlers().get(PROXY));
+        syncTx(test.getPbftPeerHandlers().get(PROXY));
+        */
+    }
+}

--- a/yggdrash-node/src/test/java/io/yggdrash/node/api/BranchApiImplTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/api/BranchApiImplTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Akashic Foundation
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package io.yggdrash.node.api;
+
+import io.yggdrash.TestConstants;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.yggdrash.node.api.JsonRpcConfig.BRANCH_API;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BranchApiImplTest {
+
+    private static final Logger log = LoggerFactory.getLogger(BranchApiImplTest.class);
+    private final String branchId = TestConstants.yggdrash().toString();
+
+    @Test
+    public void branchApiIsNotNull() {
+        assertThat(BRANCH_API).isNotNull();
+    }
+
+    @Test
+    public void getBranchesTest() {
+        try {
+            assertThat(BRANCH_API.getBranches()).isNotNull();
+        } catch (Exception exception) {
+            log.debug("getBranchesTest :: exception : " + exception);
+        }
+    }
+
+    @Test
+    public void getValidatorsTest() {
+        try {
+            assertThat(BRANCH_API.getValidators(branchId)).isNotNull();
+        } catch (Exception exception) {
+            log.debug("getValidatorsTest :: exception : " + exception);
+        }
+    }
+}

--- a/yggdrash-node/src/test/java/io/yggdrash/node/api/PeerApiImplTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/api/PeerApiImplTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Akashic Foundation
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package io.yggdrash.node.api;
+
+import io.yggdrash.TestConstants;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.yggdrash.node.api.JsonRpcConfig.PEER_API;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeerApiImplTest {
+
+    private static final Logger log = LoggerFactory.getLogger(PeerApiImplTest.class);
+    private final String branchId = TestConstants.yggdrash().toString();
+
+    @Test
+    public void blockApiIsNotNull() {
+        assertThat(PEER_API).isNotNull();
+    }
+
+    @Test
+    public void getAllActivePeerTest() {
+        try {
+            assertThat(PEER_API.getAllActivePeer()).isNotNull();
+        } catch (Exception exception) {
+            log.debug("getAllActivePeerTest :: exception : " + exception);
+        }
+    }
+}

--- a/yggdrash-node/src/test/java/io/yggdrash/node/broadcast/BroadcastTxToValidatorTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/broadcast/BroadcastTxToValidatorTest.java
@@ -33,6 +33,7 @@ public class BroadcastTxToValidatorTest extends TcpNodeTesting {
     public void test() {
         // arrange
         // validator
+        //TODO Import the validator node service into the test
         TestNode validatorNode = createAndStartNode(32801, true);
         List<String> validatorList = Collections.singletonList(validatorNode.getPeer().getYnodeUri());
         // proxyNode


### PR DESCRIPTION
healthCheck 시 catchUpRequest 가 동작하도록 수정하였으며, catchUpRequest 가 발생하는 3가지 상황(syncBlock, ping, broadcastBlock) 에서의 프로세스 동작 확인 및 존재하는 grpc 요청 사항에 대한 프로세스를 확인하기 위하여 테스트 코드를 추가하였습니다.
