### PR TITLE
Remove addBlock from syncBlock

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainSyncManager.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainSyncManager.java
@@ -177,12 +177,6 @@ public class BlockChainSyncManager implements SyncManager {
         }
 
         reqSyncBlockToHandlers(blockChain);
-
-        try {
-            blockChain.addBlock(block, false);
-        } catch (Exception e) {
-            log.warn("CatchUp block error={}", e.getMessage());
-        }
     }
 
     // When syncBlock is called (BlockServiceConsumer)


### PR DESCRIPTION
ReqSyncBlockToHandlers -> SyncBlock 시 현재 높이까지 Block을 동기화 받기 때문에, syncBlock 후 다시 브로드캐스트 받았던 블록을 다시 add 할 필요가 없어 삭제합니다. 
SyncBlock 완료 후 같은 높이의 블록을 다시 addBlock 하여 CatchUp SyncRequest 시마다 Unknown BlockHeight 예외가 발생합니다. 