### PR TITLE
Feature/contract store

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ContractExecutor.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ContractExecutor.java
@@ -11,12 +11,10 @@ import io.yggdrash.contract.core.annotation.ContractBranchStateStore;
 import io.yggdrash.contract.core.annotation.ContractChannelField;
 import io.yggdrash.contract.core.annotation.ContractStateStore;
 import io.yggdrash.contract.core.annotation.ContractTransactionReceipt;
-import io.yggdrash.contract.core.annotation.InjectEvent;
 import io.yggdrash.contract.core.channel.ContractMethodType;
+import io.yggdrash.core.blockchain.BranchId;
 import io.yggdrash.core.blockchain.LogIndexer;
-import io.yggdrash.core.blockchain.SystemProperties;
 import io.yggdrash.core.blockchain.Transaction;
-import io.yggdrash.core.blockchain.osgi.service.VersioningContract;
 import io.yggdrash.core.consensus.ConsensusBlock;
 import io.yggdrash.core.exception.errorcode.SystemError;
 import io.yggdrash.core.runtime.result.BlockRuntimeResult;
@@ -26,10 +24,9 @@ import io.yggdrash.core.store.LogStore;
 import io.yggdrash.core.store.StoreAdapter;
 import io.yggdrash.core.store.TransactionReceiptStore;
 import org.apache.commons.codec.binary.Base64;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.launch.Framework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.util.encoders.Hex;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -45,10 +42,8 @@ import java.util.concurrent.locks.ReentrantLock;
 public class ContractExecutor {
     private static final Logger log = LoggerFactory.getLogger(ContractExecutor.class);
 
-    private final Framework framework;
     private final ContractStore contractStore;
 
-    private final SystemProperties systemProperties;
     private final ContractCacheImpl contractCache;
     private TransactionReceiptAdapter trAdapter;
     private final LogIndexer logIndexer;
@@ -56,20 +51,17 @@ public class ContractExecutor {
 
     private final ReentrantLock locker = new ReentrantLock();
     private final Condition isBlockExecuting = locker.newCondition();
-
     private boolean isTx = false;
 
-
-    ContractExecutor(Framework framework, ContractStore contractStore, SystemProperties systemProperties,
-                     LogStore logStore) {
-        this.framework = framework;
+    ContractExecutor(ContractStore contractStore, LogStore logStore) {
         this.contractStore = contractStore;
-        this.systemProperties = systemProperties;
         this.logIndexer = new LogIndexer(logStore, contractStore.getTransactionReceiptStore());
-        contractCache = new ContractCacheImpl();
-        trAdapter = new TransactionReceiptAdapter();
-        coupler = new ContractChannelCoupler();
+        this.contractCache = new ContractCacheImpl();
+        this.trAdapter = new TransactionReceiptAdapter();
+        this.coupler = new ContractChannelCoupler();
     }
+
+    // TODO Implements endBlock Executions
 
     String getLog(long index) {
         return logIndexer.getLog(index);
@@ -83,122 +75,63 @@ public class ContractExecutor {
         return logIndexer.curIndex();
     }
 
-    void injectFields(Bundle bundle, Object service, boolean isSystemContract)
-            throws IllegalAccessException {
+    public void injectField(ArrayList<Object> services) throws IllegalAccessException {
 
-        Field[] fields = service.getClass().getDeclaredFields();
-        for (Field field : fields) {
-            field.setAccessible(true);
+        for (Object service : services) {
+            Field[] fields = service.getClass().getDeclaredFields();
 
-            for (Annotation annotation : field.getDeclaredAnnotations()) {
-                if (annotation.annotationType().equals(ContractStateStore.class)) {
-                    String bundleSymbolicName = bundle.getSymbolicName();
-                    byte[] bundleSymbolicSha3 = HashUtil.sha3omit12(bundleSymbolicName.getBytes());
-                    String nameSpace = new String(Base64.encodeBase64(bundleSymbolicSha3));
-                    log.debug("bundleSymbolicName {} , nameSpace {}", bundleSymbolicName, nameSpace);
-                    StoreAdapter adapterStore = new StoreAdapter(contractStore.getTmpStateStore(), nameSpace);
-                    field.set(service, adapterStore); //default => tmpStateStore
-                }
+            for (Field field : fields) {
+                field.setAccessible(true);
 
-                if (isSystemContract && annotation.annotationType().equals(ContractBranchStateStore.class)) {
-                    field.set(service, contractStore.getBranchStore());
-                }
+                for (Annotation annotation : field.getDeclaredAnnotations()) {
+                    if (annotation.annotationType().equals(ContractStateStore.class)) {
+                        String nameSpace = namespace(service.getClass().getName());
+                        log.debug("serviceName {} , nameSpace {}", service.getClass().getName(), nameSpace);
+                        StoreAdapter adapterStore = new StoreAdapter(contractStore.getTmpStateStore(), nameSpace);
+                        field.set(service, adapterStore); //default => tmpStateStore
+                    }
 
-                if (annotation.annotationType().equals(ContractTransactionReceipt.class)) {
-                    field.set(service, trAdapter);
-                }
+                    if (annotation.annotationType().equals(ContractBranchStateStore.class)) {
+                        field.set(service, contractStore.getBranchStore());
+                    }
 
-                if (annotation.annotationType().equals(ContractChannelField.class)) {
-                    field.set(service, coupler);
-                }
+                    if (annotation.annotationType().equals(ContractTransactionReceipt.class)) {
+                        field.set(service, trAdapter);
+                    }
 
-                if (systemProperties != null
-                        && annotation.annotationType().equals(InjectEvent.class)
-                        && field.getType().isAssignableFrom(systemProperties.getEventStore().getClass())) {
-                    field.set(service, systemProperties.getEventStore());
+                    if (annotation.annotationType().equals(ContractChannelField.class)) {
+                        field.set(service, coupler);
+                    }
                 }
             }
         }
-
-        contractCache.cacheContract(bundle.getLocation(), service);
     }
 
-    private Object callContractMethod(String contractVersion, Object service, String methodName, JsonObject params,
-                                      ContractMethodType methodType, TransactionReceipt txReceipt,
-                                      JsonObject endBlockParams) {
+    private String namespace(String name) {
+        byte[] bundleSymbolicSha3 = HashUtil.sha3omit12(name.getBytes());
+        return new String(Base64.encodeBase64(bundleSymbolicSha3));
+    }
 
-        Map<String, Method> methodMap = contractCache.getContractMethodMap(
-                String.format("%s/%s", ContractConstants.SUFFIX_SYSTEM_CONTRACT, contractVersion), methodType); //temporary
+    public Object query(Map<String, Object> serviceMap, String contractVersion, String methodName, JsonObject params) {
+        Object service = serviceMap.get(contractVersion);
+        if (service == null) {
+            log.error("This service that contract version {} is not registered", contractVersion);
+        }
 
-        if (methodMap == null || methodMap.get(methodName) == null) {
-            txReceipt.setStatus(ExecuteStatus.ERROR);
-            txReceipt.addLog("Method Type is not exist");
+        Method method = contractCache.getContractMethodMap(contractVersion, ContractMethodType.QUERY, service).get(methodName);
+
+        if (method == null) {
+            log.error("Not found query method: {}", methodName);
             return null;
         }
 
-        Method method = methodMap.get(methodName);
         try {
-            if (methodType == ContractMethodType.INVOKE) {
-                //
-                trAdapter.setTransactionReceipt(txReceipt);
-            }
-
-            if (method.getParameterCount() == 0) {
-                return method.invoke(service);
-            } else {
-                if (methodType == ContractMethodType.END_BLOCK) {
-                    return method.invoke(service, endBlockParams);
-                } else {
-                    return method.invoke(service, params);
-                }
-            }
-        } catch (IllegalAccessException e) {
-            log.error("CallContractMethod : {} and bundle {} ", methodName, contractVersion);
-        } catch (InvocationTargetException e) {
-            log.debug("CallContractMethod ApplicationErrorLog : {}", e.getCause().toString());
-            trAdapter.addLog(e.getCause().getMessage());
-
-            if (log.isDebugEnabled()) {
-                e.printStackTrace();
-            }
+            return method.invoke(service, params);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            log.error("Query method failed with {}", e.getMessage());
         }
-
         return null;
-    }
 
-    public Object query(String contractVersion, Object service, String methodName, JsonObject params) {
-
-        return callContractMethod(
-                contractVersion, service, methodName, params, ContractMethodType.QUERY, null, null);
-    }
-
-    private Set<Map.Entry<String, JsonObject>> invoke(
-            String contractVersion, Object service, JsonObject txBody, TransactionReceipt txReceipt) {
-
-        callContractMethod(contractVersion, service, txBody.get("method").getAsString(),
-                txBody.getAsJsonObject("params"), ContractMethodType.INVOKE, txReceipt, null);
-        return contractStore.getTmpStateStore().changeValues();
-    }
-
-    // TODO fix End Block call by execution
-    private List<Object> endBlock(String location, Object service, JsonObject endBlockParams) {
-        List<Object> results = new ArrayList<>();
-        for (Bundle bundle : framework.getBundleContext().getBundles()) {
-            contractCache.cacheContract(location, service);
-            // TODO change contract version
-            Map<String, Method> endBlockMethods = contractCache.getEndBlockMethods().get(bundle.getLocation());
-            if (endBlockMethods != null) {
-                endBlockMethods.forEach((k, m) -> {
-                    Object result = callContractMethod(
-                            location, service, k, null, ContractMethodType.END_BLOCK, null, endBlockParams);
-                    if (result != null) {
-                        results.add(result);
-                    }
-                });
-            }
-        }
-
-        return results;
     }
 
     TransactionRuntimeResult executeTx(Map<String, Object> serviceMap, Transaction tx) {
@@ -216,16 +149,17 @@ public class ContractExecutor {
         TransactionReceipt txReceipt = createTransactionReceipt(tx);
         TransactionRuntimeResult txRuntimeResult = new TransactionRuntimeResult(tx);
 
-        JsonObject txBody = tx.getBody().getBody();
-        String contractVersion = txBody.get("contractVersion").getAsString();
-        Object service = serviceMap.get(contractVersion);
-
-        if (service != null) {
-            txRuntimeResult.setChangeValues(invoke(contractVersion, service, txBody, txReceipt));
-        } else {
-            txReceipt.setStatus(ExecuteStatus.ERROR);
-            txReceipt.addLog(SystemError.CONTRACT_VERSION_NOT_FOUND.toString());
+        Set<Map.Entry<String, JsonObject>> result = null;
+        try {
+            result = getRuntimeResult(serviceMap, tx, txReceipt);
+        } catch (ExecutorException e) {
+            exceptionHandler(e, txReceipt);
         }
+
+        if (result != null) {
+            txRuntimeResult.setChangeValues(result);
+        }
+
         txRuntimeResult.setTransactionReceipt(txReceipt);
         contractStore.getTmpStateStore().close(); // clear(revert) tmpStateStore
         locker.unlock();
@@ -236,6 +170,7 @@ public class ContractExecutor {
         locker.lock();
         isTx = false;
         // Set Coupler Contract and contractCache
+        // TODO: update coupler logic
         coupler.setContract(serviceMap, contractCache);
 
         List<Transaction> txList = nextBlock.getBody().getTransactionList();
@@ -247,31 +182,88 @@ public class ContractExecutor {
         }
 
         BlockRuntimeResult blockRuntimeResult = new BlockRuntimeResult(nextBlock);
+
         for (Transaction tx : txList) {
+
             // get all exceptions
             TransactionReceipt txReceipt = createTransactionReceipt(tx);
-
             txReceipt.setBlockId(nextBlock.getHash().toString());
             txReceipt.setBlockHeight(nextBlock.getIndex());
             txReceipt.setBranchId(nextBlock.getBranchId().toString());
 
-            JsonObject txBody = tx.getBody().getBody();
-            String contractVersion = txBody.get("contractVersion").getAsString();
-            Object service = serviceMap.get(contractVersion);
+            Set<Map.Entry<String, JsonObject>> result = null;
+            try {
+                result = getRuntimeResult(serviceMap, tx, txReceipt);
+            } catch (ExecutorException e) {
+                exceptionHandler(e, txReceipt);
+            }
 
-            if (service != null) {
-                blockRuntimeResult.setBlockResult(invoke(contractVersion, service, txBody, txReceipt));
-            } else {
-                txReceipt.setStatus(ExecuteStatus.ERROR);
-                txReceipt.addLog(SystemError.CONTRACT_VERSION_NOT_FOUND.toString());
+            if (result != null) {
+                blockRuntimeResult.setBlockResult(result);
             }
 
             blockRuntimeResult.addTxReceipt(txReceipt);
             log.debug("{} : {}", txReceipt.getTxId(), txReceipt.isSuccess());
+
         }
+
         contractStore.getTmpStateStore().close(); // clear(revert) tmpStateStore
         locker.unlock();
         return blockRuntimeResult;
+    }
+
+    private Set<Map.Entry<String, JsonObject>> getRuntimeResult(Map<String, Object> serviceMap, Transaction tx, TransactionReceipt txReceipt) throws ExecutorException {
+
+        BranchId branchId = tx.getBranchId();
+        JsonObject txBody = tx.getBody().getBody();
+        // TODO Check if txBody.get("contractVersion") == null
+
+        String contractVersion = null;
+
+        if (txBody.get("contractVersion") == null) {
+            contractVersion = Hex.toHexString(tx.getHeader().getType());
+        } else {
+            contractVersion = txBody.get("contractVersion").getAsString();
+        }
+
+        String methodName = txBody.get("method").getAsString();
+        JsonObject params = txBody.getAsJsonObject("params");
+
+        Object service = serviceMap.get(contractVersion);
+
+        if (service == null) {
+            log.error("This service that contract version {} is not registered", contractVersion);
+            throw new ExecutorException(SystemError.CONTRACT_VERSION_NOT_FOUND);
+
+        }
+
+        Method method = contractCache.getContractMethodMap(contractVersion, ContractMethodType.INVOKE, service).get(methodName);
+
+        if (method == null) {
+            log.error("Not found contract method: {}", methodName);
+            throw new ExecutorException(SystemError.CONTRACT_METHOD_NOT_FOUND);
+        }
+
+        trAdapter.setTransactionReceipt(txReceipt);
+
+        try {
+            if (method.getParameterCount() == 0) {
+                method.invoke(service);
+            } else {
+                method.invoke(service, params);
+            }
+
+        } catch (IllegalAccessException e) {
+            log.error("CallContractMethod : {} and bundle {} ", methodName, contractVersion);
+        } catch (InvocationTargetException e) {
+            log.debug("CallContractMethod ApplicationErrorLog : {}", e.getCause().toString());
+            trAdapter.addLog(e.getCause().getMessage());
+        } catch (IllegalArgumentException e) {
+            e.getStackTrace();
+            log.error(e.getMessage());
+        }
+
+        return contractStore.getTmpStateStore().changeValues();
     }
 
     void commitBlockResult(BlockRuntimeResult result) {
@@ -295,70 +287,28 @@ public class ContractExecutor {
         String txId = tx.getHash().toString();
         long txSize = tx.getBody().getLength();
         String issuer = tx.getAddress().toString();
-        String contractVersion = tx.getBody().getBody().get("contractVersion").getAsString();
 
-        return new TransactionReceiptImpl(txId, txSize, issuer, contractVersion);
+        if (tx.getBody().getBody().get("contractVersion") == null) {
+            return new TransactionReceiptImpl(txId, txSize, issuer);
+        }
+        return new TransactionReceiptImpl(txId, txSize, issuer,
+                tx.getBody().getBody().get("contractVersion").getAsString());
     }
 
-
-    public TransactionRuntimeResult versioningService(Transaction tx) throws IllegalAccessException {
-        VersioningContract.VersioningContractService service = new VersioningContract.VersioningContractService();
-
-        locker.lock();
-        while (!isTx) {
-            try {
-                isBlockExecuting.await();
-            } catch (InterruptedException e) {
-                log.warn("executeTx err : {} ", e.getMessage());
-            }
+    private void exceptionHandler(ExecutorException e, TransactionReceipt receipt) {
+        SystemError error = e.getCode();
+        switch (error) {
+            case CONTRACT_VERSION_NOT_FOUND:
+                receipt.setStatus(ExecuteStatus.ERROR);
+                receipt.addLog(SystemError.CONTRACT_VERSION_NOT_FOUND.toString());
+                break;
+            case CONTRACT_METHOD_NOT_FOUND:
+                receipt.setStatus(ExecuteStatus.ERROR);
+                receipt.addLog(SystemError.CONTRACT_METHOD_NOT_FOUND.toString());
+                break;
+            default:
+                log.error(e.getMessage());
+                break;
         }
-        isTx = true;
-
-        TransactionReceipt txReceipt = createTransactionReceipt(tx);
-        TransactionRuntimeResult txRuntimeResult = new TransactionRuntimeResult(tx);
-
-        // inject
-
-        Field[] fields = service.getClass().getDeclaredFields();
-
-        for (Field field : fields) {
-            field.setAccessible(true);
-            for (Annotation annotation : field.getDeclaredAnnotations()) {
-                if (annotation.annotationType().equals(ContractStateStore.class)) {
-                    StoreAdapter adapterStore = new StoreAdapter(contractStore.getStateStore(), "versioning");
-                    field.set(service, adapterStore); //default => tmpStateStore
-                }
-                if (annotation.annotationType().equals(ContractTransactionReceipt.class)) {
-                    field.set(service, trAdapter);
-                }
-
-                if (annotation.annotationType().equals(ContractBranchStateStore.class)) {
-                    field.set(service, contractStore.getBranchStore());
-                }
-            }
-        }
-
-        JsonObject txBody = tx.getBody().getBody();
-        String contractVersion = txBody.get("contractVersion").getAsString();
-        String methodName = txBody.get("method").getAsString();
-
-        contractCache.cacheContract(contractVersion, service);
-
-        Method method = contractCache.getContractMethodMap(contractVersion, ContractMethodType.INVOKE).get(methodName);
-
-        trAdapter.setTransactionReceipt(txReceipt);
-
-        try {
-            method.invoke(service, txBody);
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        }
-
-        txRuntimeResult.setChangeValues(contractStore.getTmpStateStore().changeValues());
-
-        txRuntimeResult.setTransactionReceipt(txReceipt);
-        contractStore.getTmpStateStore().close();
-        locker.unlock();
-        return txRuntimeResult;
     }
 }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ContractManager.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ContractManager.java
@@ -10,12 +10,12 @@ import io.yggdrash.core.blockchain.Transaction;
 import io.yggdrash.core.blockchain.genesis.GenesisBlock;
 import io.yggdrash.core.blockchain.osgi.framework.BundleService;
 import io.yggdrash.core.blockchain.osgi.framework.FrameworkLauncher;
+import io.yggdrash.core.blockchain.osgi.service.VersioningContract;
 import io.yggdrash.core.consensus.ConsensusBlock;
 import io.yggdrash.core.runtime.result.BlockRuntimeResult;
 import io.yggdrash.core.runtime.result.TransactionRuntimeResult;
 import io.yggdrash.core.store.ContractStore;
 import io.yggdrash.core.store.LogStore;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -53,14 +53,14 @@ public class ContractManager {
     private final String contractRepositoryUrl;
     private final String contractPath;
     private final SystemProperties systemProperties;
-    private final Map<String, Object> serviceMap; // contractVersion, service of bundle
-
     private ContractExecutor contractExecutor;
 
     private final BundleService bundleService;
     private final HashMap<BranchId, FrameworkLauncher> frameworkHashMap = new HashMap<>();
     private final DefaultConfig defaultConfig;
     private final GenesisBlock genesis;
+
+    private Map<String, Object> serviceMap;
 
     ContractManager(GenesisBlock genesis, FrameworkLauncher frameworkLauncher, BundleService bundleService, DefaultConfig defaultConfig,
                     ContractStore contractStore, LogStore logStore, SystemProperties systemProperties) {
@@ -71,20 +71,27 @@ public class ContractManager {
 
         this.contractPath = defaultConfig.getContractPath();
         this.contractRepositoryUrl = defaultConfig.getContractRepositoryUrl();
-
         this.systemProperties = systemProperties;
-        this.serviceMap = new HashMap<>();
 
-        // todo: remove This.
-        contractExecutor = new ContractExecutor(frameworkLauncher.getFramework(), contractStore, systemProperties, logStore);
+        contractExecutor = new ContractExecutor(contractStore, logStore);
 
         this.frameworkHashMap.put(frameworkLauncher.getBranchId(), frameworkLauncher);
         this.bundleService = bundleService;
         this.defaultConfig = defaultConfig;
         this.genesis = genesis;
 
+        this.serviceMap = new HashMap<>();
+
         initBootBundles();
 
+        VersioningContract.VersioningContractService service = new VersioningContract.VersioningContractService();
+        serviceMap.put(ContractConstants.VERSIONING_TRANSACTION, service);
+
+        try {
+            contractExecutor.injectField(new ArrayList<>(serviceMap.values()));
+        } catch (IllegalAccessException e) {
+            log.error(e.getMessage());
+        }
     }
 
     private void initBootBundles() {
@@ -113,7 +120,6 @@ public class ContractManager {
 
             verifyContractFile(contractFile, contractVersion);
 
-            BundleContext context = frameworkHashMap.get(bootBranchId).getBundleContext();
             Bundle bundle = getBundle(bootBranchId, contractVersion);
 
             if (bundle == null) {
@@ -136,12 +142,6 @@ public class ContractManager {
             }
 
             registerServiceMap(bootBranchId, contractVersion, bundle);
-
-            try {
-                inject(context, bundle);
-            } catch (IllegalAccessException e) {
-                log.error("Bundle {} failed to inject with {}", bundle.getSymbolicName(), e.getMessage());
-            }
         }
     }
 
@@ -171,7 +171,7 @@ public class ContractManager {
 
         for (ServiceReference serviceRef : serviceRefs) {
             Object service = context.getService(serviceRef);
-            contractExecutor.injectFields(bundle, service, isSystemContract);
+//            contractExecutor.injectFields(bundle, service, isSystemContract);
         }
     }
 
@@ -227,8 +227,9 @@ public class ContractManager {
 
     public void registerServiceMap(BranchId branchId, ContractVersion contractVersion, Bundle bundle) {
         BundleContext context = findBundleContext(branchId);
-        Object obj = context.getService(bundle.getRegisteredServices()[0]);
-        this.serviceMap.put(contractVersion.toString(), obj);
+        Object service = context.getService(bundle.getRegisteredServices()[0]);
+        this.serviceMap.put(contractVersion.toString(), service);
+
     }
 
     public void uninstall(BranchId branchId, ContractVersion contractVersion) {
@@ -324,8 +325,7 @@ public class ContractManager {
     }
 
     public Object query(BranchId branchId, String contractVersion, String methodName, JsonObject params) {
-        Bundle bundle = bundleService.getBundle(findBundleContext(branchId), ContractVersion.of(contractVersion));
-        return bundle != null ? contractExecutor.query(contractVersion, serviceMap.get(contractVersion), methodName, params) : null;
+        return contractExecutor.query(serviceMap, contractVersion, methodName, params);
     }
 
     public BlockRuntimeResult executeTxs(ConsensusBlock nextBlock) {
@@ -333,24 +333,8 @@ public class ContractManager {
     }
 
     public TransactionRuntimeResult executeTx(Transaction tx) {
-        switch (Hex.encodeHexString(tx.getHeader().getType())) {
-            case ContractConstants.BUNDLE_TRANSACTION:
-                log.debug("Contract Executor type is bundle");
-                return contractExecutor.executeTx(serviceMap, tx);
-            case ContractConstants.VERSIONING_TRANSACTION:
-                log.debug("Contract Executor type is versioning");
-                try {
-                    return contractExecutor.versioningService(tx);
-                } catch (IllegalAccessException e) {
-                    log.error(e.getMessage());
-                    return null;
-                }
-            default:
-                log.error("Unknown Contract Type in Transaction Header");
-                return null;
-        }
+        return contractExecutor.executeTx(serviceMap, tx);
 
-//        return contractExecutor.executeTx(serviceMap, tx);
     }
 
     public void commitBlockResult(BlockRuntimeResult result) {
@@ -423,15 +407,15 @@ public class ContractManager {
         return contractFile.delete();
     }
 
-    public Map<String, Object> getServiceMap() {
-        return this.serviceMap;
-    }
-
     private String contractFilePath(ContractVersion contractVersion) {
         return this.contractPath + File.separator + contractVersion + ".jar";
     }
 
     public HashMap<BranchId, FrameworkLauncher> getFrameworkHashMap() {
         return frameworkHashMap;
+    }
+
+    public Map<String, Object> getServiceMap() {
+        return serviceMap;
     }
 }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ExecutorException.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ExecutorException.java
@@ -1,0 +1,18 @@
+package io.yggdrash.core.blockchain.osgi;
+
+import io.yggdrash.core.exception.errorcode.SystemError;
+
+public class ExecutorException extends Exception {
+
+    private final SystemError code;
+
+    public ExecutorException(SystemError code) {
+        super(code.toString());
+        this.code = code;
+    }
+
+    public SystemError getCode() {
+        return this.code;
+    }
+
+}

--- a/yggdrash-core/src/main/java/io/yggdrash/core/exception/errorcode/SystemError.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/exception/errorcode/SystemError.java
@@ -21,7 +21,8 @@ public enum SystemError {
     //Errors are included in the exception handling message.
     VALID(33000),                      //1000000011101000
     BRANCH_NOT_FOUND(33001),           //1000000011101001
-    CONTRACT_VERSION_NOT_FOUND(33002)  //1000000011101010
+    CONTRACT_VERSION_NOT_FOUND(33002),  //1000000011101010
+    CONTRACT_METHOD_NOT_FOUND(33003)    //1000000011101011
     ;
     private int code;
 
@@ -41,12 +42,18 @@ public enum SystemError {
         return code;
     }
 
+
+    @Override
     public String toString() {
+
         if (code == BRANCH_NOT_FOUND.code) {
             return "Branch doesn't exist";
         }
         if (code == CONTRACT_VERSION_NOT_FOUND.code) {
             return "ContractVersion doesn't exist";
+        }
+        if (code == CONTRACT_METHOD_NOT_FOUND.code) {
+            return "Contract Method doesn't exist";
         }
 
         return "";

--- a/yggdrash-core/src/test/java/io/yggdrash/BlockChainTestUtils.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/BlockChainTestUtils.java
@@ -19,7 +19,6 @@ package io.yggdrash;
 import com.google.gson.JsonObject;
 import io.yggdrash.common.config.Constants;
 import io.yggdrash.common.config.DefaultConfig;
-import io.yggdrash.common.contract.BranchContract;
 import io.yggdrash.common.contract.ContractVersion;
 import io.yggdrash.common.util.TimeUtils;
 import io.yggdrash.core.blockchain.BlockChain;
@@ -52,7 +51,6 @@ import io.yggdrash.core.store.PbftBlockStoreMock;
 import io.yggdrash.core.wallet.Wallet;
 import io.yggdrash.proto.PbftProto;
 import org.junit.Assert;
-import org.osgi.framework.Bundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -187,23 +185,7 @@ public class BlockChainTestUtils {
                 .withSystemProperties(systemProperties)
                 .build();
 
-
-        for (BranchContract bc : genesis.getBranch().getBranchContracts()) {
-            try {
-                Bundle bundle = contractManager.install(genesis.getBranchId(), bc.getContractVersion(), true);
-                Assert.assertNotNull("bundle is null ", bundle);
-                contractManager.start(bundle);
-                contractManager.inject(genesis.getBranchId(), bc.getContractVersion());
-                contractManager.registerServiceMap(genesis.getBranchId(), bc.getContractVersion(), bundle);
-            } catch (Exception e) {
-                log.error(e.getMessage());
-            }
-        }
-
         Assert.assertTrue(contractManager.getBundles(genesis.getBranchId()).length
-                >= genesis.getBranch().getBranchContracts().size());
-
-        Assert.assertTrue(contractManager.getServiceMap().size()
                 >= genesis.getBranch().getBranchContracts().size());
 
         BlockChainManager blockChainManager = new BlockChainManagerImpl(bcStore);

--- a/yggdrash-core/src/test/java/io/yggdrash/ContractTestUtils.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/ContractTestUtils.java
@@ -43,10 +43,10 @@ public class ContractTestUtils {
             params.addProperty("contract" , new String(Base64.encodeBase64(contractBinary)));
         }
 
-        params.addProperty("contractVersion", "4adc453cbd99b3be960118e9eced4b5dad435d0f");
-        params.addProperty("method", "updateProposer");
+//        params.addProperty("contractVersion", "4adc453cbd99b3be960118e9eced4b5dad435d0f");
+//        params.addProperty("method", "updateProposer");
 
-        return params;
+        return txBodyJson("updateProposer", params);
     }
 
     public static JsonObject versionVoteTxBodyJson(String txId, boolean agree) {
@@ -54,10 +54,16 @@ public class ContractTestUtils {
         params.addProperty("txId", txId);
         params.addProperty("agree", agree);
         params.addProperty("method", "vote");
-        params.addProperty("contractVersion", "4adc453cbd99b3be960118e9eced4b5dad435d0f");
+        return txBodyJson("vote", params);
 
-        return params;
+    }
 
+    private static JsonObject txBodyJson(String method, JsonObject params) {
+        JsonObject txBody = new JsonObject();
+        txBody.addProperty("method", method);
+        txBody.add("params", params);
+
+        return txBody;
     }
 
     public static JsonObject createParams(String key, String value) {

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/osgi/ContractManagerTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/osgi/ContractManagerTest.java
@@ -30,7 +30,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 
@@ -58,7 +57,7 @@ public class ContractManagerTest {
         this.executor = manager.getContractExecutor();
     }
 
-    public void printBundles() {
+    private void printBundles() {
         Bundle[] bundles = this.manager.getBundles(branchId);
         log.info("The number of installed bundles: {}", bundles.length);
         for (Bundle bundle : bundles) {
@@ -125,12 +124,7 @@ public class ContractManagerTest {
         }
 
         Bundle[] bundles = manager.getBundles(branchId);
-        Map<String, Object> serviceMap = manager.getServiceMap();
-
         Assert.assertTrue("Failed to install COIN-CONTRACT on osgi", bundles.length > 1);
-        Assert.assertNotNull("Failed to register COIN_CONTRACT on service map",
-                serviceMap.get(contractVersion.toString()));
-
         printBundles();
     }
 

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/osgi/VesionContractTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/osgi/VesionContractTest.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
 public class VesionContractTest {
     private static final VersioningContract.VersioningContractService service =
             new VersioningContract.VersioningContractService();
@@ -86,13 +87,12 @@ public class VesionContractTest {
                 getClass().getClassLoader().getResource(String.format("contracts/%s.jar", updateContract))).getFile();
 
         JsonObject params = ContractTestUtils.versionUpdateTxBodyJson(new File(filePath));
-        service.updateProposer(params);
+        service.updateProposer(params.getAsJsonObject("params"));
 
         assertThat(receipt.getStatus()).isEqualTo(ExecuteStatus.SUCCESS);
 
     }
 
-    @Test
     public void votingSuccessTest() throws Exception {
         TransactionReceipt updateReceipt = createTxReceipt(issuer1);
         adapter.setTransactionReceipt(updateReceipt);
@@ -101,17 +101,18 @@ public class VesionContractTest {
                 getClass().getClassLoader().getResource(String.format("contracts/%s.jar", updateContract))).getFile();
 
         JsonObject updateParam = ContractTestUtils.versionUpdateTxBodyJson(new File(filePath));
-        service.updateProposer(updateParam);
+        service.updateProposer(updateParam.getAsJsonObject("params"));
 
         assertThat(updateReceipt.getStatus()).isEqualTo(ExecuteStatus.SUCCESS);
 
         // file upload & start vote
 
         JsonObject agree = ContractTestUtils.versionVoteTxBodyJson(updateReceipt.getTxId(), true);
+        JsonObject agreeParam = agree.getAsJsonObject("params");
         JsonObject disagree = ContractTestUtils.versionVoteTxBodyJson(updateReceipt.getTxId(), true);
 
         // vote validator-1 : agree
-        service.vote(agree);
+        service.vote(agreeParam);
 
 
         // vote validator-2 : agree
@@ -119,7 +120,7 @@ public class VesionContractTest {
         voteReceipt2.setTxId(updateReceipt.getTxId());
         adapter.setTransactionReceipt(voteReceipt2);
 
-        service.vote(agree);
+        service.vote(agreeParam);
 
         assertThat(voteReceipt2.getStatus()).isEqualTo(ExecuteStatus.SUCCESS);
 
@@ -127,7 +128,7 @@ public class VesionContractTest {
         voteReceipt3.setTxId(updateReceipt.getTxId());
         adapter.setTransactionReceipt(voteReceipt3);
 
-        service.vote(agree);
+        service.vote(agreeParam);
 
         assertThat(voteReceipt3.getStatus()).isEqualTo(ExecuteStatus.SUCCESS);
 
@@ -137,50 +138,6 @@ public class VesionContractTest {
 
     }
 
-//    @Test
-//    public void votingFailTest() throws Exception {
-//        String issuer = "a2b0f5fce600eb6c595b28d6253bed92be0568ed";
-//        TransactionReceipt preReceipt = new TransactionReceiptImpl();
-//        preReceipt.setBlockHeight(10L);
-//        preReceipt.setIssuer(issuer);
-//        preReceipt.setTxId("a2b0f5fce600eb6c595b28d6253bed92be0568eda2b0f5fce600eb6c595b28d6253bed92be0568ed");
-//        txReceiptField.set(service, preReceipt);
-//        Path currentRelativePath = Paths.get("");
-//        String s = currentRelativePath.toAbsolutePath().toString();
-//        String s2 = String.format("%s/%s", s, "build");
-//        String result = String.format("%s/%s", s2, "contract");
-//        JsonObject params = createUpdateParams(result);
-//        service.updateProposer(params);
-//
-//        service.vote(createVoteParams(true));
-//        String issuer2 = "d2a5721e80dc439385f3abc5aab0ac4ed2b1cd95";
-//        preReceipt.setIssuer(issuer2);
-//
-//        service.vote(createVoteParams(false));
-//
-//        String issuer3 = "d2a5721e80dc439385f3abc5aab0ac4ed2b1cd95";
-//        preReceipt.setIssuer(issuer3);
-//        TransactionReceipt receipt = service.vote(createVoteParams(false));
-//    }
-//
-//    @Test
-//    public void notValidatorvotingTest() throws Exception {
-//        String issuer = "0dc4393d2a5721e885f3abc5aab0ac4ed2b1cd95";
-//        TransactionReceipt preReceipt = new TransactionReceiptImpl();
-//        preReceipt.setBlockHeight(10L);
-//        preReceipt.setIssuer(issuer);
-//        preReceipt.setTxId("a2b0f5fce600eb6c595b28d6253bed92be0568eda2b0f5fce600eb6c595b28d6253bed92be0568ed");
-//        txReceiptField.set(service, preReceipt);
-//        Path currentRelativePath = Paths.get("");
-//        String s = currentRelativePath.toAbsolutePath().toString();
-//        String s2 = String.format("%s/%s", s, "build");
-//        String result = String.format("%s/%s", s2, "contract");
-//        JsonObject params = createUpdateParams(result);
-//        service.updateProposer(params);
-//        TransactionReceipt receipt = service.vote(createVoteParams(true));
-//        assertEquals(ExecuteStatus.FALSE, receipt.getStatus());
-//    }
-
     private TransactionReceipt createTxReceipt(String issuer) {
         TransactionReceipt receipt = new TransactionReceiptImpl();
         receipt.setIssuer(issuer);
@@ -189,57 +146,6 @@ public class VesionContractTest {
 
         return receipt;
     }
-
-//    private JsonObject createVoteParams(boolean vote) {
-//        JsonObject params = new JsonObject();
-//        params.addProperty("txId",
-//                "a2b0f5fce600eb6c595b28d6253bed92be0568eda2b0f5fce600eb6c595b28d6253bed92be0568ed");
-//        params.addProperty("agree", vote);
-//        return params;
-//    }
-//
-//    private JsonObject createUpdateParams(String path) {
-//        String bash64String = new String(convertVersionToBase64(path));
-//        JsonObject params = new JsonObject();
-//        params.addProperty("contractVersion", "4adc453cbd99b3be960118e9eced4b5dad435d0f");
-//        params.addProperty("contract", bash64String);
-//        return params;
-//    }
-//
-//    private byte[] convertVersionToBase64(String contractPath) {
-//        contractFile(contractPath);
-//        if (contractFile.exists()) {
-//            byte[] fileArray = loadContract(contractFile);
-//            return base64Enc(fileArray);
-//        }
-//        return null;
-//    }
-//
-//    private void contractFile(String path) {
-//        try (Stream<Path> filePathStream = Files.walk(Paths.get(String.valueOf(path)))) {
-//            filePathStream.forEach(p -> {
-//                File contractPath = new File(p.toString());
-//                this.contractFile = contractPath;
-//            });
-//        } catch (IOException e) {
-//            e.printStackTrace();
-//        }
-//    }
-//
-//    private static byte[] loadContract(File contractFile) {
-//        byte[] contractBinary;
-//        try (FileInputStream inputStream = new FileInputStream(contractFile)) {
-//            contractBinary = new byte[Math.toIntExact(contractFile.length())];
-//            inputStream.read(contractBinary);
-//        } catch (IOException e) {
-//            return null;
-//        }
-//        return contractBinary;
-//    }
-//
-//    private static byte[] base64Enc(byte[] buffer) {
-//        return Base64.encodeBase64(buffer);
-//    }
 
     public class TestBranchStateStore implements BranchStateStore {
         ValidatorSet set = new ValidatorSet();


### PR DESCRIPTION
ContractManager serviceMap에 VersionContract Service 등록

ContractExecutor
- Block, TX execute 로직 통합
- ExecutorException 추가

ContractCache
 - methodMap 등록 시점 변경
    기존에는 executor 실행 시에 전체 로드하고 이후에는 등록할 수 없었음.
    service를 실행할 때 검색하고, 없으면 찾아서 등록시키는 방식으로 변경
