### PR TITLE
Calculate stateRoot before making a new block from pbft service

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/common/util/VerifierUtils.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/common/util/VerifierUtils.java
@@ -113,9 +113,9 @@ public class VerifierUtils {
      * @return boolean
      */
     private static boolean verifyTimestamp(Long timeStamp) {
-        long hour = (1000 * 60 * 60);
+        long twoHour = (1000 * 60 * 60) * 2;
         long curTime = System.currentTimeMillis();
-        return timeStamp.compareTo(curTime + hour) < 0 && timeStamp.compareTo(curTime - hour) > 0;
+        return timeStamp.compareTo(curTime + twoHour) < 0 && timeStamp.compareTo(curTime - twoHour) > 0;
     }
 
     public static boolean verifySignature(Transaction tx) {

--- a/yggdrash-core/src/main/java/io/yggdrash/common/util/VerifierUtils.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/common/util/VerifierUtils.java
@@ -113,9 +113,9 @@ public class VerifierUtils {
      * @return boolean
      */
     private static boolean verifyTimestamp(Long timeStamp) {
-        long twoHour = (1000 * 60 * 60) * 2;
+        long hour = (1000 * 60 * 60);
         long curTime = System.currentTimeMillis();
-        return timeStamp.compareTo(curTime + twoHour) < 0 && timeStamp.compareTo(curTime - twoHour) > 0;
+        return timeStamp.compareTo(curTime + hour) < 0 && timeStamp.compareTo(curTime - hour) > 0;
     }
 
     public static boolean verifySignature(Transaction tx) {

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChain.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChain.java
@@ -19,7 +19,6 @@ package io.yggdrash.core.blockchain;
 import io.yggdrash.common.contract.BranchContract;
 import io.yggdrash.common.contract.ContractVersion;
 import io.yggdrash.core.blockchain.osgi.ContractEventListener;
-import io.yggdrash.core.blockchain.osgi.ContractManager;
 import io.yggdrash.core.consensus.ConsensusBlock;
 import io.yggdrash.core.consensus.ConsensusBlockChain;
 
@@ -33,8 +32,6 @@ public interface BlockChain<T, V> extends ConsensusBlockChain<T, V> {
     Map<String, List<String>> addBlock(ConsensusBlock<T> block, boolean broadcast); // return errorLogs
 
     Map<String, List<String>> addTransaction(Transaction tx); // return errorLogs
-
-    ContractManager getContractManager();
 
     List<BranchContract> getBranchContracts();
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainImpl.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainImpl.java
@@ -48,8 +48,6 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
 
     private boolean isFullSynced = false;
 
-    public ReentrantLock lock2 = new ReentrantLock();
-
     public BlockChainImpl(Branch branch,
                           ConsensusBlock<T> genesisBlock,
                           BranchStore branchStore,
@@ -93,8 +91,6 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
             log.debug("BlockChain Load in Storage");
             // Load Block Chain Information
             blockChainManager.loadTransaction(); // load stateRoot when updateTxCache!
-            // Load StateRoot
-            //blockChainManager.setPendingStateRoot(contractManager.getOriginStateRoot());
         }
     }
 
@@ -102,6 +98,7 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
         // After executing the transactions of GenesisBlock,
         // put them in the txStore with the stateRootHash of pendingStateStore.
         blockChainManager.initGenesis(genesisBlock);
+        System.out.println("InitGenesis : stateRoot => " + new Sha3Hash(genesisBlock.getHeader().getStateRoot(), true));
         addBlock(genesisBlock, false);
 
         // Add Meta Information
@@ -154,7 +151,6 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
             }
             // Add best Block
             branchStore.setBestBlock(nextBlock);
-
             // Run Block Transactions
             // TODO run block execute move to other process (or thread)
             // TODO last execute block will invoke
@@ -166,6 +162,7 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
                         ? new Sha3Hash(blockResult.getBlockResult().get("stateRoot").get("stateHash").getAsString())
                         : contractManager.getOriginStateRoot();
                 Sha3Hash nextBlockStateRoot = new Sha3Hash(nextBlock.getHeader().getStateRoot(), true);
+                System.out.println("AddBlock : Index => " + nextBlock.getIndex() + ", StateRoot => " +  new Sha3Hash(nextBlock.getHeader().getStateRoot(), true) + ", BlockResultStateRoot => " + blockResultStateRoot);
                 if (!nextBlockStateRoot.equals(blockResultStateRoot)) {
                     log.warn("Add block failed. Invalid stateRoot. BlockStateRoot : {}, CurStateRoot : {}"
                             , nextBlockStateRoot, blockResultStateRoot);
@@ -175,28 +172,16 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
                 branchStore.setLastExecuteBlock(nextBlock);
             }
 
+            // BlockChainManager add nextBlock to the blockStore, set the lastConfirmedBlock to nextBlock,
+            // and then batch the transactions.
+            blockChainManager.addBlock(nextBlock);
+
             BlockRuntimeResult endBlockResult = contractManager.endBlock(nextBlock);
-            if (endBlockResult.getBlockResult().size() > 0) {
-                String endBlockStateRoot = endBlockResult.getBlockResult().get("stateRoot").get("stateHash").getAsString();
-                log.debug("endBlockStateRoot : {} ", endBlockStateRoot);
-            }
 
             // Fire contract event
             getContractEventList(endBlockResult).stream()
                     .filter(event -> !contractEventListenerList.isEmpty())
                     .forEach(event -> contractEventListenerList.forEach(l -> l.endBlock(event)));
-
-            lock2.lock();
-            blockChainManager.batchTxs(nextBlock, contractManager.getOriginStateRoot());
-
-            // PendingStateStore is still running without reset.
-            Sha3Hash curStateRoot = reExecuteAndRemoveFromPendingPool(blockChainManager.getUnconfirmedTxs());
-
-            // BlockChainManager add nextBlock to the blockStore, set the lastConfirmedBlock to nextBlock,
-            // and then batch the transactions.
-            blockChainManager.addBlock(nextBlock);
-            blockChainManager.batchTxs(nextBlock, curStateRoot);
-            lock2.unlock();
 
             if (!listenerList.isEmpty() && broadcast) {
                 listenerList.forEach(listener -> listener.chainedBlock(nextBlock));
@@ -218,34 +203,6 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
                 .map(Receipt::getEvents)
                 .forEach(contractEventList::addAll);
         return contractEventList;
-    }
-
-    private Sha3Hash reExecuteAndRemoveFromPendingPool(List<Transaction> txs) {
-        // PendingStateStore is still running without reset.
-        contractManager.resetPendingStateStore();
-        Sha3Hash curStateRoot = contractManager.getOriginStateRoot();
-        for (Transaction tx : txs) {
-            curStateRoot = addPendingTxs(tx);
-            if (curStateRoot == null) { // Err tx in pendingPool
-                blockChainManager.flushUnconfirmedTx(tx.getHash());
-            }
-        }
-
-        return curStateRoot;
-    }
-
-    private Sha3Hash addPendingTxs(Transaction tx) {
-        lock2.lock();
-        try {
-            Sha3Hash curStateRootHash = contractManager.executePendingTxWithStateRoot(tx);
-            log.trace("executeAndAddToPendingPool : curStateRootHash {}", curStateRootHash);
-            if (curStateRootHash != null) {
-                blockChainManager.addTransaction(tx, curStateRootHash);
-            }
-            return curStateRootHash;
-        } finally {
-            lock2.unlock();
-        }
     }
 
     @Override
@@ -275,8 +232,7 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
             TransactionRuntimeResult txResult = contractManager.executeTx(tx); //checkTx
             log.trace("contractManager.executeTx Result: {}", txResult.toString());
             if (txResult.getReceipt().getStatus() != ExecuteStatus.ERROR) {
-                // Execute tx before adding tx to pending pool. Err tx would not be added.
-                executeAndAddToPendingPool(tx);
+                blockChainManager.addTransaction(tx);
 
                 if (!listenerList.isEmpty() && broadcast) {
                     listenerList.forEach(listener -> listener.receivedTransaction(tx));
@@ -290,20 +246,6 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
             }
         } else {
             return BusinessError.getErrorLogsMap(verifyResult);
-        }
-    }
-
-    @Override
-    public Sha3Hash executeAndAddToPendingPool(Transaction tx) {
-        lock2.lock();
-        try {
-            // return pendingTx stateRootHash
-            if (!blockChainManager.contains(tx)) {
-                return addPendingTxs(tx);
-            }
-            return null;
-        } finally {
-            lock2.unlock();
         }
     }
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainImpl.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainImpl.java
@@ -98,7 +98,6 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
         // After executing the transactions of GenesisBlock,
         // put them in the txStore with the stateRootHash of pendingStateStore.
         blockChainManager.initGenesis(genesisBlock);
-        System.out.println("InitGenesis : stateRoot => " + new Sha3Hash(genesisBlock.getHeader().getStateRoot(), true));
         addBlock(genesisBlock, false);
 
         // Add Meta Information
@@ -162,7 +161,6 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
                         ? new Sha3Hash(blockResult.getBlockResult().get("stateRoot").get("stateHash").getAsString())
                         : contractManager.getOriginStateRoot();
                 Sha3Hash nextBlockStateRoot = new Sha3Hash(nextBlock.getHeader().getStateRoot(), true);
-                System.out.println("AddBlock : Index => " + nextBlock.getIndex() + ", StateRoot => " +  new Sha3Hash(nextBlock.getHeader().getStateRoot(), true) + ", BlockResultStateRoot => " + blockResultStateRoot);
                 if (!nextBlockStateRoot.equals(blockResultStateRoot)) {
                     log.warn("Add block failed. Invalid stateRoot. BlockStateRoot : {}, CurStateRoot : {}"
                             , nextBlockStateRoot, blockResultStateRoot);

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainManager.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainManager.java
@@ -18,6 +18,7 @@ import io.yggdrash.core.consensus.ConsensusBlock;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public interface BlockChainManager<T> {
 
@@ -35,7 +36,7 @@ public interface BlockChainManager<T> {
 
     void addTransaction(Transaction tx);
 
-    void flushUnconfirmedTx(Sha3Hash key);
+    void flushUnconfirmedTxs(Set<Sha3Hash> keys);
 
     void updateTxCache(Block block);
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainManager.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainManager.java
@@ -18,8 +18,6 @@ import io.yggdrash.core.consensus.ConsensusBlock;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public interface BlockChainManager<T> {
 
@@ -33,21 +31,13 @@ public interface BlockChainManager<T> {
 
     void addBlock(ConsensusBlock<T> nextBlock);
 
-    //void addBlock(ConsensusBlock<T> nextBlock, Sha3Hash stateRoot);
-
-    void batchTxs(ConsensusBlock<T> block, Sha3Hash stateRoot);
+    void batchTxs(ConsensusBlock<T> block);
 
     void addTransaction(Transaction tx);
-
-    void addTransaction(Transaction tx, Sha3Hash stateRootHash);
-
-    void flushUnconfirmedTxs(Set<Sha3Hash> keys);
 
     void flushUnconfirmedTx(Sha3Hash key);
 
     void updateTxCache(Block block);
-
-    //void setPendingStateRoot(Sha3Hash stateRootHash);
 
     ConsensusBlock<T> getLastConfirmedBlock();
 
@@ -60,8 +50,6 @@ public interface BlockChainManager<T> {
     Collection<Transaction> getRecentTxs();
 
     List<Transaction> getUnconfirmedTxs();
-
-    Map<Sha3Hash, List<Transaction>> getUnconfirmedTxsWithStateRoot();
 
     List<Transaction> getUnconfirmedTxsWithLimit(long limit);
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainManagerImpl.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainManagerImpl.java
@@ -173,7 +173,7 @@ public class BlockChainManagerImpl<T> implements BlockChainManager<T> {
                     addTransaction(tx);
                 }
             }
-            //batchTxs(nextBlock);
+            batchTxs(nextBlock);
 
             // Store Block Index and Block Data
             this.blockStore.addBlock(nextBlock);
@@ -185,7 +185,7 @@ public class BlockChainManagerImpl<T> implements BlockChainManager<T> {
     }
 
     @Override
-    public void batchTxs(ConsensusBlock<T> block, Sha3Hash stateRoot) {
+    public void batchTxs(ConsensusBlock<T> block) {
         try {
             lock.lock();
             if (block == null || block.getBlock() == null || block.getBody().getTransactionList() == null) {
@@ -194,7 +194,7 @@ public class BlockChainManagerImpl<T> implements BlockChainManager<T> {
 
             Set<Sha3Hash> keys = block.getBlock().getBody().getTransactionList().stream()
                     .map(Transaction::getHash).collect(Collectors.toSet());
-            transactionStore.batch(keys, stateRoot);
+            transactionStore.batch(keys);
         } finally {
             lock.unlock();
         }
@@ -207,20 +207,6 @@ public class BlockChainManagerImpl<T> implements BlockChainManager<T> {
         } catch (Exception e) {
             throw new FailedOperationException(e);
         }
-    }
-
-    @Override
-    public void addTransaction(Transaction tx, Sha3Hash stateRootHash) {
-        try {
-            transactionStore.addTransaction(tx, stateRootHash);
-        } catch (Exception e) {
-            throw new FailedOperationException(e);
-        }
-    }
-
-    @Override
-    public void flushUnconfirmedTxs(Set<Sha3Hash> keys) {
-        transactionStore.flush(keys);
     }
 
     @Override
@@ -288,11 +274,6 @@ public class BlockChainManagerImpl<T> implements BlockChainManager<T> {
     @Override
     public List<Transaction> getUnconfirmedTxs() {
         return new ArrayList<>(transactionStore.getUnconfirmedTxs());
-    }
-
-    @Override
-    public Map<Sha3Hash, List<Transaction>> getUnconfirmedTxsWithStateRoot() {
-        return transactionStore.getUnconfirmedTxsWithStateRoot();
     }
 
     @Override

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainManagerImpl.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainManagerImpl.java
@@ -210,8 +210,8 @@ public class BlockChainManagerImpl<T> implements BlockChainManager<T> {
     }
 
     @Override
-    public void flushUnconfirmedTx(Sha3Hash key) {
-        transactionStore.flush(key);
+    public void flushUnconfirmedTxs(Set<Sha3Hash> keys) {
+        transactionStore.flush(keys);
     }
 
     @Override

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ContractManager.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ContractManager.java
@@ -368,27 +368,12 @@ public class ContractManager implements ContractEventListener {
         return contractExecutor.executeTxs(serviceMap, nextBlock);
     }
 
-    public BlockRuntimeResult executePendingTxs(List<Transaction> txs) {
-        resetPendingStateStore();
-        return contractExecutor.executePendingTxs(serviceMap, txs);
+    public BlockRuntimeResult executeTxs(List<Transaction> txs) {
+        return contractExecutor.executeTxs(serviceMap, txs);
     }
 
     public TransactionRuntimeResult executeTx(Transaction tx) {
         return contractExecutor.executeTx(serviceMap, tx);
-    }
-
-    public Sha3Hash executePendingTxWithStateRoot(Transaction tx) {
-        return contractExecutor.executePendingTxWithStateRoot(serviceMap, tx);
-    }
-
-    /*
-    private void resetPendingStateStore() {
-        contractStore.getPendingStateStore().close();
-    }
-    */
-
-    public void resetPendingStateStore() {
-        contractStore.getPendingStateStore().close();
     }
 
     // file actions.

--- a/yggdrash-core/src/main/java/io/yggdrash/core/consensus/ConsensusBlockChain.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/consensus/ConsensusBlockChain.java
@@ -1,10 +1,9 @@
 package io.yggdrash.core.consensus;
 
-import io.yggdrash.common.Sha3Hash;
 import io.yggdrash.common.contract.vo.dpoa.ValidatorSet;
 import io.yggdrash.core.blockchain.BlockChainManager;
 import io.yggdrash.core.blockchain.BranchId;
-import io.yggdrash.core.blockchain.Transaction;
+import io.yggdrash.core.blockchain.osgi.ContractManager;
 import io.yggdrash.core.store.BlockKeyStore;
 
 import java.util.List;
@@ -12,6 +11,7 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 public interface ConsensusBlockChain<T, V> {
+
     BranchId getBranchId();
 
     Consensus getConsensus();
@@ -26,15 +26,14 @@ public interface ConsensusBlockChain<T, V> {
 
     Map<String, List<String>> addBlock(ConsensusBlock<T> block, boolean broadcast); // return errorLogs
 
-    //void executeAndAddToPendingPool(Transaction tx);
-
-    Sha3Hash executeAndAddToPendingPool(Transaction tx); // return stateRootHash
-
     boolean isValidator(String addr);
 
     ValidatorSet getValidators();
 
+    ContractManager getContractManager();
+
     BlockChainManager<T> getBlockChainManager();
 
     ReentrantLock getLock();
+
 }

--- a/yggdrash-core/src/main/java/io/yggdrash/core/store/TransactionStore.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/store/TransactionStore.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -226,21 +225,10 @@ public class TransactionStore implements ReadWriterStore<Sha3Hash, Transaction> 
         return unconfirmedTxs;
     }
 
-    private void flush(Set<Sha3Hash> keys) {
+    public void flush(Set<Sha3Hash> keys) {
         pendingPool.removeAll(keys);
         pendingKeys.removeAll(keys);
         log.trace("flushSize={} remainPendingSize={}", keys.size(), pendingKeys.size());
-    }
-
-    public void flush(Sha3Hash key) {
-        lock.lock();
-        try {
-            pendingPool.remove(key);
-            pendingKeys.remove(key);
-            log.trace("remainPendingSize={}", pendingKeys.size());
-        } finally {
-            lock.unlock();
-        }
     }
 
     public void updateCache(Block block) {

--- a/yggdrash-core/src/test/java/io/yggdrash/BlockChainTestUtils.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/BlockChainTestUtils.java
@@ -66,6 +66,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class BlockChainTestUtils {
     private static final GenesisBlock genesis;
@@ -109,8 +111,8 @@ public class BlockChainTestUtils {
 
     }
 
-    private static List<ConsensusBlock<PbftProto.PbftBlock>> sampleBlockList = createBlockList(
-            new ArrayList<>(), genesisBlock(), null, 100);
+    private static List<ConsensusBlock<PbftProto.PbftBlock>> sampleBlockList
+            = createBlockListWithoutTxs(100, genesisBlock());
 
     public static List<ConsensusBlock<PbftProto.PbftBlock>> getSampleBlockList() {
         return sampleBlockList;
@@ -125,31 +127,39 @@ public class BlockChainTestUtils {
     }
 
     public static ConsensusBlock<PbftProto.PbftBlock> createNextBlock() {
-        return createNextBlock(new PbftBlockMock(genesis.getBlock()));
+        PbftBlockMock genesisBLock = new PbftBlockMock(genesis.getBlock());
+        return new PbftBlockMock(BlockImpl.nextBlock(
+                TestConstants.wallet(),
+                Collections.emptyList(),
+                genesisBLock.getHeader().getStateRoot(),
+                genesisBLock));
     }
 
     public static ConsensusBlock<PbftProto.PbftBlock> createNextBlock(ConsensusBlock prevBlock) {
-        return createNextBlock(Collections.emptyList(), prevBlock);
-    }
-
-    public static ConsensusBlock<PbftProto.PbftBlock> createNextBlock(List<Transaction> blockBody,
-                                                                      ConsensusBlock prevBlock) {
-        byte[] stateRoot = ContractTestUtils.calStateRoot(prevBlock, blockBody).getBytes();
-        return new PbftBlockMock(BlockImpl.nextBlock(TestConstants.wallet(), blockBody, stateRoot, prevBlock));
-    }
-
-    public static ConsensusBlock<PbftProto.PbftBlock> createNextBlock(Wallet wallet,
-                                                                      List<Transaction> blockBody,
-                                                                      ConsensusBlock prevBlock) {
-        byte[] stateRoot = ContractTestUtils.calStateRoot(prevBlock, blockBody).getBytes();
-        return new PbftBlockMock(BlockImpl.nextBlock(wallet, blockBody, stateRoot, prevBlock));
+        return new PbftBlockMock(BlockImpl.nextBlock(
+                TestConstants.wallet(),
+                Collections.emptyList(),
+                prevBlock.getHeader().getStateRoot(),
+                prevBlock));
     }
 
     public static ConsensusBlock<PbftProto.PbftBlock> createNextBlock(List<Transaction> blockBody,
                                                                       ConsensusBlock prevBlock,
                                                                       ContractManager contractManager) {
-        byte[] stateRoot = ContractTestUtils.calStateRoot(contractManager, blockBody).getBytes();
+        byte[] stateRoot = contractManager != null
+                ? ContractTestUtils.calStateRoot(contractManager, blockBody).getBytes()
+                : ContractTestUtils.calStateRoot(prevBlock, blockBody).getBytes();
         return new PbftBlockMock(BlockImpl.nextBlock(TestConstants.wallet(), blockBody, stateRoot, prevBlock));
+    }
+
+    public static ConsensusBlock<PbftProto.PbftBlock> createNextBlock(Wallet wallet,
+                                                                      List<Transaction> blockBody,
+                                                                      ConsensusBlock prevBlock,
+                                                                      ContractManager contractManager) {
+        byte[] stateRoot = contractManager != null
+                ? ContractTestUtils.calStateRoot(contractManager, blockBody).getBytes()
+                : ContractTestUtils.calStateRoot(prevBlock, blockBody).getBytes();
+        return new PbftBlockMock(BlockImpl.nextBlock(wallet, blockBody, stateRoot, prevBlock));
     }
 
     public static ConsensusBlock<PbftProto.PbftBlock> createSpecificHeightBlock(long index,
@@ -256,9 +266,8 @@ public class BlockChainTestUtils {
 
         Sha3Hash genesisStateRootHash;
         if (genesis.getContractTxs().size() > 0) {
-            genesisStateRootHash = new Sha3Hash(contractManager.executePendingTxs(genesis.getContractTxs())
+            genesisStateRootHash = new Sha3Hash(contractManager.executeTxs(genesis.getContractTxs())
                     .getBlockResult().get("stateRoot").get("stateHash").getAsString());
-            //blockChainManager.setPendingStateRoot(genesisStateRootHash);
         } else {
             genesisStateRootHash = new Sha3Hash(Constants.EMPTY_HASH);
         }
@@ -285,46 +294,42 @@ public class BlockChainTestUtils {
         BlockChain branch = branchGroup.getBranch(branchId);
         List<Transaction> txs =
                 branch.getBlockChainManager().getUnconfirmedTxsWithLimit(Constants.Limit.BLOCK_SYNC_SIZE);
-        branch.addBlock(createNextBlock(txs, branch.getBlockChainManager().getLastConfirmedBlock()));
+        branch.addBlock(createNextBlock(txs, branch.getBlockChainManager().getLastConfirmedBlock(), branch.getContractManager()));
     }
 
     public static void setBlockHeightOfBlockChain(BlockChain blockChain, int height) {
         List<ConsensusBlock<PbftProto.PbftBlock>> blockList = new ArrayList<>();
         ConsensusBlock<PbftProto.PbftBlock> curBlock
                 = blockChain.getBlockChainManager().getBlockByIndex(blockChain.getBlockChainManager().getLastIndex());
-        ConsensusBlock<PbftProto.PbftBlock> nextBlock = createNextBlock(curBlock);
-        blockList = createBlockList(blockList, nextBlock, null, height);
+        blockList = createBlockListWithoutTxs(height, curBlock);
 
         for (ConsensusBlock block : blockList) {
             blockChain.addBlock(block, false);
         }
     }
 
-    public static List<ConsensusBlock<PbftProto.PbftBlock>> createBlockListFilledWithTx(int height, int txSize) {
+    public static List<ConsensusBlock<PbftProto.PbftBlock>> createBlockListWithTxs(int blockHeight, int txSize, ContractManager contractManager) {
         List<ConsensusBlock<PbftProto.PbftBlock>> blockList = new ArrayList<>();
-        List<Transaction> blockBody = new ArrayList<>();
-
-        for (int i = 0; i < txSize; i++) {
-            blockBody.add(createTransferTx());
+        List<Transaction> blockBody = IntStream.range(0, txSize).mapToObj(i -> createTransferTx()).collect(Collectors.toList());
+        blockList.add(createNextBlock(blockBody, genesisBlock(), contractManager));
+        for (int i = 0; i < blockHeight - 1; i++) {
+            blockList.add(createNextBlock(blockBody, blockList.get(i), contractManager));
         }
-
-        return createBlockList(blockList, createNextBlock(blockBody, genesisBlock()), blockBody, height);
+        return blockList;
     }
 
-    private static List<ConsensusBlock<PbftProto.PbftBlock>> createBlockList(
-            List<ConsensusBlock<PbftProto.PbftBlock>> blockList,
-            ConsensusBlock<PbftProto.PbftBlock> prevBlock,
-            List<Transaction> blockBody,
-            int height) {
-        while (blockList.size() < height) {
-            blockList.add(prevBlock);
-            if (blockBody != null) {
-                createBlockList(blockList, createNextBlock(blockBody, prevBlock), blockBody, height);
-            } else {
-                createBlockList(blockList, createNextBlock(prevBlock), null, height);
-            }
+    public static List<ConsensusBlock<PbftProto.PbftBlock>> createBlockListWithoutTxs(int blockHeight, ConsensusBlock<PbftProto.PbftBlock> curBlock) {
+        List<ConsensusBlock<PbftProto.PbftBlock>> blockList = new ArrayList<>();
+        if (curBlock != null && curBlock.getIndex() != 0L) {
+            blockList.add(createNextBlock(curBlock));
+        } else {
+            blockList.add(createNextBlock()); // nextBlock of genesisBlock
         }
-        return blockList.size() > 0 ? blockList : Collections.emptyList();
+
+        for (int i = 0; i < blockHeight - 1; i++) {
+            blockList.add(createNextBlock(blockList.get(i)));
+        }
+        return blockList;
     }
 
     public static Transaction createContractProposeTx(String contractVersion, String proposalType) {

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BlockChainManagerImplTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BlockChainManagerImplTest.java
@@ -86,7 +86,7 @@ public class BlockChainManagerImplTest {
         ConsensusBlock<PbftProto.PbftBlock> block = generateBlockWithTxs(true);
         assertEquals(32000, blockChainManager.verify(block));
         blockChainManager.addBlock(block);
-        blockChainManager.batchTxs(block, new Sha3Hash(block.getHeader().getStateRoot(), true));
+
         assertTrue(blockChainManager.contains(block));
         assertEquals(block, blockChainManager.getBlockByHash(block.getHash()));
         assertEquals(block, blockChainManager.getBlockByIndex(1));
@@ -104,7 +104,7 @@ public class BlockChainManagerImplTest {
         ConsensusBlock<PbftProto.PbftBlock> blockWithInvalidTx = generateBlockWithTxs(false);
         assertEquals(32000, blockChainManager.verify(blockWithInvalidTx));
         blockChainManager.addBlock(blockWithInvalidTx);
-        blockChainManager.batchTxs(blockWithInvalidTx, new Sha3Hash(blockWithInvalidTx.getHeader().getStateRoot(), true));
+
         assertEquals(3, blockChainManager.countOfBlocks());
         assertEquals(20, blockChainManager.countOfTxs());
         assertEquals(20, blockChainManager.getRecentTxs().size()); //invalid tx was excluded
@@ -119,7 +119,7 @@ public class BlockChainManagerImplTest {
         if (!valid) {
             txs.add(BlockChainTestUtils.createInvalidTransferTx());
         }
-        return BlockChainTestUtils.createNextBlock(txs, blockChainManager.getLastConfirmedBlock());
+        return BlockChainTestUtils.createNextBlock(txs, blockChainManager.getLastConfirmedBlock(), null);
     }
 
 }

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BranchGroupTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/BranchGroupTest.java
@@ -184,7 +184,8 @@ public class BranchGroupTest {
         while (blockChain.getBlockChainManager().getLastIndex() < 10) {
             log.debug("Last Index : {}", blockChain.getBlockChainManager().getLastIndex());
             branchGroup.addBlock(block);
-            ConsensusBlock nextBlock = BlockChainTestUtils.createNextBlock(Collections.emptyList(), block);
+            ConsensusBlock nextBlock = BlockChainTestUtils.createNextBlock(
+                    Collections.emptyList(), block, blockChain.getContractManager());
             addMultipleBlock(nextBlock);
         }
     }

--- a/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/osgi/ContractExecutorTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/blockchain/osgi/ContractExecutorTest.java
@@ -160,7 +160,7 @@ public class ContractExecutorTest {
 
         // Create a block with the txList which should be added to blockChain.
         ConsensusBlock<PbftProto.PbftBlock> nextBlock = BlockChainTestUtils.createNextBlock(
-                wallet, txList, genesisBlock);
+                wallet, txList, genesisBlock, manager);
 
         // Execute the created block.
         BlockRuntimeResult res = manager.executeTxs(nextBlock);
@@ -196,7 +196,8 @@ public class ContractExecutorTest {
         // Block contains same success txs
         List<Transaction> txs = IntStream.range(0, 10)
                 .mapToObj(i -> generateTx(BigInteger.valueOf(100))).collect(Collectors.toList());
-        ConsensusBlock<PbftProto.PbftBlock> nextBlock = BlockChainTestUtils.createNextBlock(wallet, txs, genesisBlock);
+        ConsensusBlock<PbftProto.PbftBlock> nextBlock = BlockChainTestUtils.createNextBlock(
+                wallet, txs, genesisBlock, manager);
         BlockRuntimeResult res = manager.executeTxs(nextBlock); // executeTxs contains commitBlockResult
 
         res.getReceipts().forEach(r -> assertEquals(ExecuteStatus.SUCCESS, r.getStatus()));
@@ -239,7 +240,8 @@ public class ContractExecutorTest {
         txs.add(errTx2);
         txs.add(successTx2);
 
-        ConsensusBlock<PbftProto.PbftBlock> nextBlock = BlockChainTestUtils.createNextBlock(wallet, txs, genesisBlock);
+        ConsensusBlock<PbftProto.PbftBlock> nextBlock = BlockChainTestUtils.createNextBlock(
+                wallet, txs, genesisBlock, manager);
         BlockRuntimeResult res = manager.executeTxs(nextBlock);
 
         assertEquals(ExecuteStatus.SUCCESS, res.getReceipts().get(0).getStatus());
@@ -266,7 +268,7 @@ public class ContractExecutorTest {
         Transaction errTx = generateTx(BigInteger.valueOf(100), notExistedVersion);
 
         ConsensusBlock<PbftProto.PbftBlock> nextBlock = BlockChainTestUtils.createNextBlock(
-                wallet, Collections.singletonList(errTx), genesisBlock);
+                wallet, Collections.singletonList(errTx), genesisBlock, manager);
 
         String errLog = SystemError.CONTRACT_VERSION_NOT_FOUND.toString();
         BlockRuntimeResult res = manager.executeTxs(nextBlock);
@@ -291,7 +293,7 @@ public class ContractExecutorTest {
 
         //success tx
         Transaction tx = generateTx(BigInteger.valueOf(100)); //method => transfer
-        nextBlock = BlockChainTestUtils.createNextBlock(wallet, Collections.singletonList(tx), genesisBlock);
+        nextBlock = BlockChainTestUtils.createNextBlock(wallet, Collections.singletonList(tx), genesisBlock, manager);
         res = manager.executeTxs(nextBlock);
 
         assertEquals(10, manager.getCurLogIndex());

--- a/yggdrash-core/src/test/java/io/yggdrash/core/net/BlockServiceConsumerTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/net/BlockServiceConsumerTest.java
@@ -49,7 +49,7 @@ public class BlockServiceConsumerTest {
         // arrange
         int height = 110;
         List<ConsensusBlock<PbftProto.PbftBlock>> blockList =
-                BlockChainTestUtils.createBlockListFilledWithTx(height, 100);
+                BlockChainTestUtils.createBlockListWithTxs(height, 100, branch.getContractManager());
 
         blockList.forEach(b -> branch.addBlock(b, false));
         Assert.assertEquals(height, blockChainManager.getLastIndex());

--- a/yggdrash-core/src/test/java/io/yggdrash/core/p2p/PeerHandlerMock.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/p2p/PeerHandlerMock.java
@@ -104,7 +104,7 @@ public class PeerHandlerMock implements BlockChainHandler {
         List<ConsensusBlock> tmp = new ArrayList<>();
         if (offset < 33) {
             for (int i = (int) offset; i < (int) offset + 33; i++) {
-                tmp.add(BlockChainTestUtils.getSampleBlockList().get(i));
+                tmp.add(BlockChainTestUtils.getSampleBlockList().get(i - 1));
             }
         }
         future.complete(tmp);

--- a/yggdrash-core/src/test/java/io/yggdrash/core/store/TransactionStoreTest.java
+++ b/yggdrash-core/src/test/java/io/yggdrash/core/store/TransactionStoreTest.java
@@ -140,6 +140,6 @@ public class TransactionStoreTest {
 
     private void batch() {
         Set<Sha3Hash> keys = ts.getUnconfirmedTxs().stream().map(Transaction::getHash).collect(Collectors.toSet());
-        ts.batch(keys, new Sha3Hash(""));
+        ts.batch(keys);
     }
 }

--- a/yggdrash-node/src/main/java/io/yggdrash/node/config/BranchConfiguration.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/config/BranchConfiguration.java
@@ -147,10 +147,12 @@ public class BranchConfiguration {
 
         Sha3Hash genesisStateRootHash;
         if (blockChainManager.countOfBlocks() > 0) {
-            genesisStateRootHash = new Sha3Hash(blockChainStore.getConsensusBlockStore().getBlockByIndex(0).getBlock().getHeader().getStateRoot(), true);
+            genesisStateRootHash = new Sha3Hash(
+                    blockChainStore.getConsensusBlockStore().getBlockByIndex(0).getBlock().getHeader().getStateRoot(),
+                    true);
         } else {
             if (genesis.getContractTxs().size() > 0) {
-                genesisStateRootHash = new Sha3Hash(contractManager.executePendingTxs(genesis.getContractTxs())
+                genesisStateRootHash = new Sha3Hash(contractManager.executeTxs(genesis.getContractTxs())
                         .getBlockResult().get("stateRoot").get("stateHash").getAsString());
             } else {
                 genesisStateRootHash = new Sha3Hash(Constants.EMPTY_HASH);

--- a/yggdrash-node/src/test/java/io/yggdrash/node/IntegrationTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/IntegrationTest.java
@@ -261,7 +261,8 @@ public class IntegrationTest extends TcpNodeTesting {
     }
 
     private static void broadcastBlocks(PeerHandlerProvider.PbftPeerHandler t, int cnt, int txSize) {
-        BlockChainTestUtils.createBlockListFilledWithTx(cnt, txSize).forEach(t::broadcastBlock);
+        // contractManager is null
+        BlockChainTestUtils.createBlockListWithTxs(cnt, txSize, null).forEach(t::broadcastBlock);
     }
 
     private static void broadcastBlock(PeerHandlerProvider.PbftPeerHandler t,

--- a/yggdrash-node/src/test/java/io/yggdrash/node/TestNode.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/TestNode.java
@@ -167,7 +167,8 @@ public class TestNode extends BootStrapNode {
             BlockChainManager blockChainManager = branch.getBlockChainManager();
             List<Transaction> txs =
                     blockChainManager.getUnconfirmedTxsWithLimit(Constants.Limit.BLOCK_SYNC_SIZE);
-            ConsensusBlock block = BlockChainTestUtils.createNextBlock(txs, blockChainManager.getLastConfirmedBlock());
+            ConsensusBlock block = BlockChainTestUtils.createNextBlock(
+                    txs, blockChainManager.getLastConfirmedBlock(), branch.getContractManager());
 
             PbftBlock newBlock = new PbftBlock(PbftProto.PbftBlock.newBuilder()
                     .setBlock(block.getBlock().getProtoBlock()).build());

--- a/yggdrash-node/src/test/java/io/yggdrash/node/api/LogApiImplTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/api/LogApiImplTest.java
@@ -100,7 +100,8 @@ public class LogApiImplTest {
         assertEquals("Tx Count", contractSize, mgr.countOfTxs());
 
         int generateTx = 33;
-        ConsensusBlock<PbftProto.PbftBlock> block = BlockChainTestUtils.createBlockListFilledWithTx(1, generateTx).get(0);
+        ConsensusBlock<PbftProto.PbftBlock> block = BlockChainTestUtils.createBlockListWithTxs(
+                1, generateTx, bc.getContractManager()).get(0);
         bc.addBlock(block);
 
         Log log = logApi.getLog(branchId, 33);

--- a/yggdrash-node/src/test/java/io/yggdrash/node/api/TransactionMockitoTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/api/TransactionMockitoTest.java
@@ -33,7 +33,6 @@ import io.yggdrash.gateway.dto.TransactionReceiptDto;
 import io.yggdrash.gateway.dto.TransactionResponseDto;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -72,7 +71,7 @@ public class TransactionMockitoTest {
         txReceiptStore = new HashMap<>();
         txApiImpl = new TransactionApiImpl(branchGroupMock);
 
-        tx = BlockChainTestUtils.createBranchTx();
+        tx = BlockChainTestUtils.createTransferTx();
         branchId = tx.getBranchId();
         txId = tx.getHash().toString();
         List<Transaction> txList = new ArrayList<>();
@@ -83,7 +82,7 @@ public class TransactionMockitoTest {
         txReceipt.setTxId(txId);
         txReceiptStore.put(txId, txReceipt);
         ConsensusBlock genesis = BlockChainTestUtils.genesisBlock();
-        block = BlockChainTestUtils.createNextBlock(txList, genesis);
+        block = BlockChainTestUtils.createNextBlock(txList, genesis, null); // contractManager is null
         blockId = block.getHash().toString();
     }
 

--- a/yggdrash-node/src/test/java/io/yggdrash/node/e2e/YeedContractE2ETest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/e2e/YeedContractE2ETest.java
@@ -115,7 +115,8 @@ public class YeedContractE2ETest extends TestConstants.SlowTest {
         assertEquals(genesis.getBody().getTransactionList().size(), mgr.countOfTxs());
         assertEquals(genesis.getBody().getTransactionList().size(), mgr.getRecentTxs().size());
 
-        ConsensusBlock<PbftProto.PbftBlock> block = BlockChainTestUtils.createNextBlock(createTxs(10), genesis);
+        ConsensusBlock<PbftProto.PbftBlock> block = BlockChainTestUtils.createNextBlock(
+                createTxs(10), genesis, bc.getContractManager());
 
         bc.addBlock(block, false);
 

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/data/BlockChainManagerMock.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/data/BlockChainManagerMock.java
@@ -23,6 +23,7 @@ import io.yggdrash.core.store.BlockChainStore;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public class BlockChainManagerMock<T> implements BlockChainManager<T> {
 
@@ -68,8 +69,8 @@ public class BlockChainManagerMock<T> implements BlockChainManager<T> {
     }
 
     @Override
-    public void flushUnconfirmedTx(Sha3Hash key) {
-        blockChainManager.flushUnconfirmedTx(key);
+    public void flushUnconfirmedTxs(Set<Sha3Hash> keys) {
+        blockChainManager.flushUnconfirmedTxs(keys);
     }
 
     @Override

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/data/BlockChainManagerMock.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/data/BlockChainManagerMock.java
@@ -23,8 +23,6 @@ import io.yggdrash.core.store.BlockChainStore;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public class BlockChainManagerMock<T> implements BlockChainManager<T> {
 
@@ -60,30 +58,13 @@ public class BlockChainManagerMock<T> implements BlockChainManager<T> {
     }
 
     @Override
-    public void batchTxs(ConsensusBlock<T> block, Sha3Hash stateRoot) {
-        blockChainManager.batchTxs(block, stateRoot);
+    public void batchTxs(ConsensusBlock<T> block) {
+        blockChainManager.batchTxs(block);
     }
-
-    /*
-    @Override
-    public void addBlock(ConsensusBlock<T> nextBlock, Sha3Hash stateRoot) {
-        blockChainManager.addBlock(nextBlock, stateRoot);
-    }
-    */
 
     @Override
     public void addTransaction(Transaction tx) {
         blockChainManager.addTransaction(tx);
-    }
-
-    @Override
-    public void addTransaction(Transaction tx, Sha3Hash stateRootHash) {
-        blockChainManager.addTransaction(tx, stateRootHash);
-    }
-
-    @Override
-    public void flushUnconfirmedTxs(Set<Sha3Hash> keys) {
-        blockChainManager.flushUnconfirmedTxs(keys);
     }
 
     @Override
@@ -95,13 +76,6 @@ public class BlockChainManagerMock<T> implements BlockChainManager<T> {
     public int getUnconfirmedTxsSize() {
         return blockChainManager.getUnconfirmedTxsSize();
     }
-
-    /*
-    @Override
-    public void setPendingStateRoot(Sha3Hash stateRootHash) {
-        blockChainManager.setPendingStateRoot(stateRootHash);
-    }
-    */
 
     @Override
     public void updateTxCache(Block block) {
@@ -141,11 +115,6 @@ public class BlockChainManagerMock<T> implements BlockChainManager<T> {
     @Override
     public List<Transaction> getUnconfirmedTxs() {
         return blockChainManager.getUnconfirmedTxs();
-    }
-
-    @Override
-    public Map<Sha3Hash, List<Transaction>> getUnconfirmedTxsWithStateRoot() {
-        return blockChainManager.getUnconfirmedTxsWithStateRoot();
     }
 
     @Override

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/data/ebft/EbftBlockChain.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/data/ebft/EbftBlockChain.java
@@ -7,7 +7,7 @@ import io.yggdrash.common.util.VerifierUtils;
 import io.yggdrash.core.blockchain.Block;
 import io.yggdrash.core.blockchain.BlockChainManager;
 import io.yggdrash.core.blockchain.BranchId;
-import io.yggdrash.core.blockchain.Transaction;
+import io.yggdrash.core.blockchain.osgi.ContractManager;
 import io.yggdrash.core.consensus.Consensus;
 import io.yggdrash.core.consensus.ConsensusBlock;
 import io.yggdrash.core.consensus.ConsensusBlockChain;
@@ -137,6 +137,11 @@ public class EbftBlockChain implements ConsensusBlockChain<EbftProto.EbftBlock, 
     }
 
     @Override
+    public ContractManager getContractManager() {
+        return null;
+    }
+
+    @Override
     public EbftBlock getGenesisBlock() {
         return genesisBlock;
     }
@@ -177,11 +182,6 @@ public class EbftBlockChain implements ConsensusBlockChain<EbftProto.EbftBlock, 
             this.lock.unlock();
         }
         return new HashMap<>();
-    }
-
-    @Override
-    public Sha3Hash executeAndAddToPendingPool(Transaction tx) {
-        return null;
     }
 
     @Override

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/data/pbft/PbftBlockChain.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/data/pbft/PbftBlockChain.java
@@ -7,7 +7,7 @@ import io.yggdrash.common.util.VerifierUtils;
 import io.yggdrash.core.blockchain.Block;
 import io.yggdrash.core.blockchain.BlockChainManager;
 import io.yggdrash.core.blockchain.BranchId;
-import io.yggdrash.core.blockchain.Transaction;
+import io.yggdrash.core.blockchain.osgi.ContractManager;
 import io.yggdrash.core.consensus.Consensus;
 import io.yggdrash.core.consensus.ConsensusBlock;
 import io.yggdrash.core.consensus.ConsensusBlockChain;
@@ -134,6 +134,11 @@ public class PbftBlockChain implements ConsensusBlockChain<PbftProto.PbftBlock, 
     }
 
     @Override
+    public ContractManager getContractManager() {
+        return null;
+    }
+
+    @Override
     public PbftBlock getGenesisBlock() {
         return genesisBlock;
     }
@@ -164,11 +169,6 @@ public class PbftBlockChain implements ConsensusBlockChain<PbftProto.PbftBlock, 
         this.blockKeyStore.put(block.getIndex(), block.getHash().getBytes());
         loggingBlock((PbftBlock) block);
         return new HashMap<>();
-    }
-
-    @Override
-    public Sha3Hash executeAndAddToPendingPool(Transaction tx) {
-        return null;
     }
 
     @Override

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/service/ebft/EbftServerStub.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/service/ebft/EbftServerStub.java
@@ -45,7 +45,7 @@ public class EbftServerStub extends EbftServiceGrpc.EbftServiceImplBase {
         log.trace("Received transaction: hash={}", tx.getHash());
         if (tx.getBranchId().equals(blockChain.getBranchId())
                 && blockChain.getBlockChainManager().verify(tx) == BusinessError.VALID.toValue()) {
-            blockChain.executeAndAddToPendingPool(tx);;
+            blockChain.getBlockChainManager().addTransaction(tx);
         }
         responseObserver.onNext(EMPTY);
         responseObserver.onCompleted();

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/service/node/TransactionServiceStub.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/service/node/TransactionServiceStub.java
@@ -73,7 +73,7 @@ public class TransactionServiceStub extends TransactionServiceGrpc.TransactionSe
                 log.trace("Received transaction: hash={}", tx.getHash());
                 if (tx.getBranchId().equals(blockChain.getBranchId())
                         && blockChain.getBlockChainManager().verify(tx) == BusinessError.VALID.toValue()) {
-                    blockChain.executeAndAddToPendingPool(tx);
+                    blockChain.getBlockChainManager().addTransaction(tx);
                     multicastTransaction(protoTx);
                 }
             }

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/service/pbft/PbftServerStub.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/service/pbft/PbftServerStub.java
@@ -63,7 +63,7 @@ public class PbftServerStub extends PbftServiceGrpc.PbftServiceImplBase {
         log.trace("Received transaction: hash={}", tx.getHash());
         if (tx.getBranchId().equals(blockChain.getBranchId())
                 && blockChain.getBlockChainManager().verify(tx) == BusinessError.VALID.toValue()) {
-            blockChain.executeAndAddToPendingPool(tx);
+            blockChain.getBlockChainManager().addTransaction(tx);
         }
         responseObserver.onNext(EMPTY);
         responseObserver.onCompleted();

--- a/yggdrash-validator/src/main/java/io/yggdrash/validator/service/pbft/PbftService.java
+++ b/yggdrash-validator/src/main/java/io/yggdrash/validator/service/pbft/PbftService.java
@@ -6,6 +6,7 @@ import io.yggdrash.common.config.Constants;
 import io.yggdrash.common.config.DefaultConfig;
 import io.yggdrash.common.contract.vo.dpoa.Validator;
 import io.yggdrash.common.util.TimeUtils;
+import io.yggdrash.contract.core.ExecuteStatus;
 import io.yggdrash.core.blockchain.Block;
 import io.yggdrash.core.blockchain.BlockBody;
 import io.yggdrash.core.blockchain.BlockHeader;
@@ -15,6 +16,7 @@ import io.yggdrash.core.consensus.ConsensusBlockChain;
 import io.yggdrash.core.consensus.ConsensusService;
 import io.yggdrash.core.exception.NotValidateException;
 import io.yggdrash.core.p2p.Peer;
+import io.yggdrash.core.runtime.result.BlockRuntimeResult;
 import io.yggdrash.core.wallet.Wallet;
 import io.yggdrash.proto.PbftProto;
 import io.yggdrash.validator.data.pbft.PbftBlock;
@@ -24,6 +26,7 @@ import io.yggdrash.validator.data.pbft.PbftStatus;
 import io.yggdrash.validator.data.pbft.PbftVerifier;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -339,10 +342,19 @@ public class PbftService implements ConsensusService<PbftProto.PbftBlock, PbftMe
     }
 
     private Block makeNewBlock(long index, byte[] prevBlockHash) {
-        Map<Sha3Hash, List<Transaction>> unconfirmedTxsWithStateRoot
-                = blockChain.getBlockChainManager().getUnconfirmedTxsWithStateRoot();
-        Sha3Hash curStateRootHash = unconfirmedTxsWithStateRoot.keySet().iterator().next();
-        List<Transaction> txList = unconfirmedTxsWithStateRoot.get(curStateRootHash);
+        List<Transaction> txList = new ArrayList<>(blockChain.getBlockChainManager().getUnconfirmedTxs());
+        Sha3Hash curStateRootHash;
+        if (txList.size() > 0) {
+            BlockRuntimeResult result = blockChain.getContractManager().executeTxs(txList);
+            curStateRootHash = new Sha3Hash(result.getBlockResult().get("stateRoot").get("stateHash").getAsString());
+            // Flush error txs from pendingPool
+            result.getReceipts().stream()
+                    .filter(receipt -> receipt.getStatus().equals(ExecuteStatus.ERROR))
+                    .forEach(receipt -> blockChain.getBlockChainManager()
+                            .flushUnconfirmedTx(new Sha3Hash(receipt.getTxId())));
+        } else {
+            curStateRootHash = blockChain.getContractManager().getOriginStateRoot();
+        }
         log.debug("makeNextBlock : stateRootHash {}, txList size {}", curStateRootHash, txList.size());
 
         BlockBody newBlockBody = new BlockBody(txList);


### PR DESCRIPTION
PBFT 서비스에서 밸리데이터가 블록 생성 전 블록실행 및 StateRoot 를 구하도록 변경하였습니다.
- PendingStateStore 와 StoreAdapterList 는 삭제
- AddTransaction 시 PendingStateRoot 를 위한 트랜잭션 실행 삭제
- TransactionStore 에 StateRoot 삭제
- AddBlock 시 PendingStateRoot 재계산 삭제 

