### PR TITLE
Reset to stateRoot of lastConfirmedBlock

### DIFF
--- a/yggdrash-common/src/main/java/io/yggdrash/common/store/StateStore.java
+++ b/yggdrash-common/src/main/java/io/yggdrash/common/store/StateStore.java
@@ -12,6 +12,8 @@ public class StateStore implements ReadWriterStore<String, JsonObject> {
     private final DbSource<byte[], byte[]> db;
     private long dbSize = 0L;
     private static final byte[] DATABASE_SIZE = "DATABASE_SIZE".getBytes();
+    private static final String STATE_ROOT = "stateRoot";
+    private static final String STATE_HASH = "stateHash";
 
 
     public StateStore(DbSource<byte[], byte[]> dbSource) {
@@ -24,6 +26,12 @@ public class StateStore implements ReadWriterStore<String, JsonObject> {
 
     public long getStateSize() {
         return dbSize;
+    }
+
+    public void setLastStateRootHash(String lastStateRootHash) {
+        JsonObject obj = new JsonObject();
+        obj.addProperty(STATE_HASH, lastStateRootHash);
+        put(STATE_ROOT, obj);
     }
     
     @Override

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainImpl.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/BlockChainImpl.java
@@ -90,7 +90,8 @@ public class BlockChainImpl<T, V> implements BlockChain<T, V> {
         } else {
             log.debug("BlockChain Load in Storage");
             // Load Block Chain Information
-            blockChainManager.loadTransaction(); // load stateRoot when updateTxCache!
+            blockChainManager.loadTransaction();
+            contractManager.revertBestBlockStateRoot(blockChainManager.getLastConfirmedBlock());
         }
     }
 

--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ContractManager.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/osgi/ContractManager.java
@@ -88,6 +88,12 @@ public class ContractManager implements ContractEventListener {
 
     }
 
+    public void revertBestBlockStateRoot(ConsensusBlock lastConfirmedBlock) {
+        String lastStateRootHash = new Sha3Hash(lastConfirmedBlock.getHeader().getStateRoot(), true).toString();
+        this.contractStore.getStateStore().setLastStateRootHash(lastStateRootHash);
+
+    }
+
     @Override
     public void endBlock(ContractEvent event) {
         versioningContractEventHandler(event);


### PR DESCRIPTION
- 노드 재 실행 시 lastConfirmedBlock 의 stateRoot 로 리셋하도록 수정
    - tx 실행 중 노드 셧다운 및 재실행 시 InvalidStateRoot 이슈
