### PR TITLE
Return errLog if parse exception occurs in sendTx and sendRawTx

### DIFF
--- a/yggdrash-gateway/src/main/java/io/yggdrash/gateway/dto/TransactionResponseDto.java
+++ b/yggdrash-gateway/src/main/java/io/yggdrash/gateway/dto/TransactionResponseDto.java
@@ -29,4 +29,11 @@ public class TransactionResponseDto {
 
         return txResDto;
     }
+
+    public static TransactionResponseDto createBy(Map<String, List<String>> logs) {
+        TransactionResponseDto txResDto = new TransactionResponseDto();
+        txResDto.logs = logs;
+
+        return txResDto;
+    }
 }

--- a/yggdrash-node/src/main/java/io/yggdrash/node/api/TransactionApiImpl.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/api/TransactionApiImpl.java
@@ -89,14 +89,26 @@ public class TransactionApiImpl implements TransactionApi {
 
     @Override
     public TransactionResponseDto sendTransaction(TransactionDto tx) {
-        Transaction transaction = TransactionDto.of(tx);
-        return addTx(transaction);
+        try {
+            Transaction transaction = TransactionDto.of(tx);
+            return addTx(transaction);
+        } catch (Exception e) {
+            log.debug("SendTransaction Exception : {}", e.getMessage());
+            return TransactionResponseDto.createBy(
+                    BusinessError.getErrorLogsMap(BusinessError.INVALID_DATA_FORMAT.toValue()));
+        }
     }
 
     @Override
     public TransactionResponseDto sendRawTransaction(byte[] bytes) {
-        Transaction transaction = TransactionImpl.parseFromRaw(bytes);
-        return addTx(transaction);
+        try {
+            Transaction transaction = TransactionImpl.parseFromRaw(bytes);
+            return addTx(transaction);
+        } catch (Exception e) {
+            log.debug("SendRawTransaction Exception : {}", e.getMessage());
+            return TransactionResponseDto.createBy(
+                    BusinessError.getErrorLogsMap(BusinessError.INVALID_DATA_FORMAT.toValue()));
+        }
     }
 
     private TransactionResponseDto addTx(Transaction transaction) {

--- a/yggdrash-node/src/test/java/io/yggdrash/node/api/TransactionApiImplTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/api/TransactionApiImplTest.java
@@ -39,6 +39,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 
 import static io.yggdrash.node.api.JsonRpcConfig.BLOCK_API;
@@ -241,6 +242,13 @@ public class TransactionApiImplTest {
     public void getRawTransactionHeaderTest() {
         assertThat(txApi.getRawTransactionHeader(yggdrashBranch, testTransactionHash))
                 .isNotNull();
+    }
+
+    @Test
+    public void sendInvalidDataFormatOfRawTx() {
+        byte[] input = "Invalid Raw Transaction Input Data".getBytes();
+        TransactionResponseDto transactionResponseDto = txApi.sendRawTransaction(input);
+        assertTrue(!transactionResponseDto.logs.isEmpty());
     }
 
     @Ignore

--- a/yggdrash-node/src/test/java/io/yggdrash/node/api/TransactionMockitoTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/api/TransactionMockitoTest.java
@@ -138,7 +138,6 @@ public class TransactionMockitoTest {
         assertThat(res.txHash).isNotEmpty();
     }
 
-    @Test(expected = FailedOperationException.class)
     public void sendInvalidRawTransaction() {
         TransactionResponseDto res = txApiImpl.sendRawTransaction(tx.toBinary());
         assertFalse(res.status);


### PR DESCRIPTION
- TxApi 의 sendTransaction, sendRawTransaction 예외 처리 
    - TransactionDto, RawTransaction 으로 Parse 예외 발생 시 ErrLog 리턴