### PR TITLE
Bugfix/log api exception handling

### DIFF
--- a/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Log.java
+++ b/yggdrash-core/src/main/java/io/yggdrash/core/blockchain/Log.java
@@ -27,6 +27,13 @@ public class Log {
         return ret;
     }
 
+    public static Log createBy(String msg) {
+        Log ret = new Log();
+        ret.msg = msg;
+
+        return ret;
+    }
+
     public long getNum() {
         return num;
     }

--- a/yggdrash-node/src/main/java/io/yggdrash/node/api/BranchApiImpl.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/api/BranchApiImpl.java
@@ -37,14 +37,6 @@ public class BranchApiImpl implements BranchApi {
     public Set<String> getValidators(String branchId) {
         BlockChain bc = branchGroup.getBranch(BranchId.of(branchId));
         return bc != null ? bc.getValidators().getValidatorMap().keySet() : new HashSet<>();
-        /*
-        if (bc != null) {
-            ValidatorSet vs = bc.getValidators();
-            return vs.getValidatorMap().keySet();
-        } else {
-            return new HashSet<>();
-        }
-        */
     }
 
 }

--- a/yggdrash-node/src/main/java/io/yggdrash/node/api/BranchApiImpl.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/api/BranchApiImpl.java
@@ -1,7 +1,6 @@
 package io.yggdrash.node.api;
 
 import com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceImpl;
-import io.yggdrash.common.contract.vo.dpoa.ValidatorSet;
 import io.yggdrash.core.blockchain.BlockChain;
 import io.yggdrash.core.blockchain.BranchGroup;
 import io.yggdrash.core.blockchain.BranchId;
@@ -10,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -36,12 +36,15 @@ public class BranchApiImpl implements BranchApi {
     @Override
     public Set<String> getValidators(String branchId) {
         BlockChain bc = branchGroup.getBranch(BranchId.of(branchId));
+        return bc != null ? bc.getValidators().getValidatorMap().keySet() : new HashSet<>();
+        /*
         if (bc != null) {
             ValidatorSet vs = bc.getValidators();
             return vs.getValidatorMap().keySet();
         } else {
-            return null;
+            return new HashSet<>();
         }
+        */
     }
 
 }

--- a/yggdrash-node/src/main/java/io/yggdrash/node/service/TransactionService.java
+++ b/yggdrash-node/src/main/java/io/yggdrash/node/service/TransactionService.java
@@ -58,6 +58,11 @@ public class TransactionService extends TransactionServiceGrpc.TransactionServic
     public void syncTx(CommonProto.SyncLimit syncLimit, StreamObserver<Proto.TransactionList> responseObserver) {
         BranchId branchId = BranchId.of(syncLimit.getBranch().toByteArray());
         log.debug("Received syncTransaction request branchId={}", branchId);
+        if (branchGroup.getBranch(branchId) == null) {
+            log.debug("Branch Not Found.");
+            return;
+        }
+
         if (!branchGroup.getBranch(branchId).isFullSynced()) {
             log.debug("Not yet fullSynced.");
             return;

--- a/yggdrash-node/src/test/java/io/yggdrash/node/api/LogApiImplTest.java
+++ b/yggdrash-node/src/test/java/io/yggdrash/node/api/LogApiImplTest.java
@@ -144,6 +144,19 @@ public class LogApiImplTest {
     }
 
     @Test
+    public void exceptionTest() {
+        assertEquals(0, logApi.curIndex("String")); //exception decoding Hex string
+        assertEquals(0, logApi.curIndex("")); //branch not found
+        assertEquals(0, logApi.curIndex("b42eb7d71e3794d192a1b5783d01a59840fcbec2")); //branch not found
+
+        assertTrue(!logApi.getLog("String", 1).getMsg().isEmpty());
+        assertTrue(!logApi.getLog("b42eb7d71e3794d192a1b5783d01a59840fcbec2", 1).getMsg().isEmpty());
+
+        assertEquals(1, logApi.getLogs("String", 1, 1).size());
+        assertEquals(1, logApi.getLogs("b42eb7d71e3794d192a1b5783d01a59840fcbec2", 1, 1).size());
+    }
+
+    @Test
     public void regexTest() {
         String log = "Propose 6a95d72869643550a485cbea0a4a8aac1092b4b185f58903b1d348383068ca42 ISSUED";
         assertTrue(Pattern.compile("^(Propose [a-f0-9]{64} ISSUED)").matcher(log).find());


### PR DESCRIPTION
- LogApi 예외 처리 
    - BranchGroup 의 getBranch() 후 NullPointerException
    - BranchId.of() 시 DecoderException
- BranchApi 의 getValidators 리턴 타입 변경
    - null -> new HashSet
- GetBranch 시 null 체크 